### PR TITLE
Changed the way style is generated

### DIFF
--- a/classes/element_helper.php
+++ b/classes/element_helper.php
@@ -114,10 +114,10 @@ class element_helper {
         list($font, $attr) = self::get_font($element);
         $fontstyle = 'font-family: ' . $font;
         if (strpos($attr, 'B') !== false) {
-            $fontstyle .= ': font-weight: bold';
+            $fontstyle .= '; font-weight: bold';
         }
         if (strpos($attr, 'I') !== false) {
-            $fontstyle .= ': font-style: italic';
+            $fontstyle .= '; font-style: italic';
         }
 
         $style = $fontstyle . '; color: ' . $element->colour . '; font-size: ' . $element->size . 'pt;';


### PR DESCRIPTION
When the style is generated if you use ":" it will write in a single line font-family, font-weight and font-style, using ";" it will write each style element in a different line.