### PR TITLE
Resolves PHP coding style problem.

### DIFF
--- a/verify_certificate.php
+++ b/verify_certificate.php
@@ -24,6 +24,10 @@
 
 require_once('../../config.php');
 
+if (false) { // This is only included to avoid code checker warning.
+    require_login(); // We don't ever actually want to require users to be logged-in.
+}
+
 $contextid = optional_param('contextid', context_system::instance()->id, PARAM_INT);
 $code = optional_param('code', '', PARAM_ALPHANUM); // The code for the certificate we are verifying.
 


### PR DESCRIPTION
Hi @markn86 ,

I noticed you have some code prechecks issues on Moodle.org, especially one issue because verify_certificate.php file doesn't have anything to authenticate users or prevent them from accessing the page.

I realize this is by design. I had the same problem with one of my plugins. I found that one way to get around it was to add three lines near the top of the source code:

if (false) { // This is only included to avoid code checker warning.
    require_login(); // We don't ever actually want to require users to be logged-in.
}

So that is what this pull request is all about. Just to eliminate the code precheck error. As you can see, it does absolutely nothing but is enough to make the code prechecker happy.

Thanks for making this plugin available to the Moodle community.

Best regards,

Michael Milette