### PR TITLE
Fixes #138. Needs UnitTests.

### DIFF
--- a/classes/ws/ValidateCertificate.php
+++ b/classes/ws/ValidateCertificate.php
@@ -1,0 +1,102 @@
+<?php
+
+
+namespace mod_customcert;
+
+global $CFG;
+require_once("$CFG->libdir/externallib.php");
+
+
+class ValidateCertificate extends \external_api
+{
+    /**
+     * Verify if the given values are valid for a issued certificate.
+     */
+    public static function validate_certificate_parameters() {
+        return new \external_function_parameters(
+                    array(
+                        'context_id' => new \external_value(PARAM_INT,
+                            'id of the course'),
+                        'code' => new \external_value(PARAM_ALPHANUM,
+                            'The code for the certificate that going to verify.')
+                    )
+        );
+    }
+
+    public static function validate_certificate_returns(){
+        return new \external_single_structure (
+            array(
+                'validated' => new \external_value(PARAM_BOOL,
+                    'If the certificate is valid or not.',
+                    True),
+                'course_id' => new \external_value(PARAM_INT, 'id of the course',
+                    False),
+                'course_fullname' => new \external_value(PARAM_ALPHANUM, 'FullName of the Course',
+                    False),
+                'course_shortname' => new \external_value(PARAM_ALPHANUM, 'ShortName of the Course',
+                    False),
+                'course_uid' => new \external_value(PARAM_ALPHANUM, 'Course External/Unique Identifier',
+                    False),
+                'course_summary' => new \external_value(PARAM_TEXT, 'Course Summary',
+                    False),
+                'student_id' => new \external_value(PARAM_INT, 'Students id',
+                    False),
+                'student_name' => new \external_value(PARAM_TEXT, 'Students Name',
+                    False),
+                'certificate_id' => new \external_value(PARAM_ALPHANUM, 'Cert Id',
+                    False),
+                'cert_issue_timestamp' => new \external_value(PARAM_INT,
+                    'Certificate Issued Date in unix timestamp format',
+                    False),
+            )
+        );
+    }
+
+    public static function validate_certificate($contextid, $code){
+        //TODO: Implement it!
+        global $DB;
+
+        $context = \context::instance_by_id($contextid);
+        if (!$cm = get_coursemodule_from_id('customcert', $context->instanceid, 0, false)){
+            throw new \invalid_parameter_exception('No context with given ID Found.');
+        }
+
+        $course = $DB->get_record('course', array('id' => $cm->course), '*',
+            MUST_EXIST);
+        $customcert = $DB->get_record('customcert', array('id' => $cm->instance));
+
+        // TODO: This SQL Should die.
+        $userfields = get_all_user_name_fields(true, 'u');
+        $sql = "SELECT ci.id, u.id as userid,$userfields, co.id as courseid,
+                   co.fullname as coursefullname, c.name as certificatename, c.verifyany
+              FROM {customcert} c
+              JOIN {customcert_issues} ci
+                ON c.id = ci.customcertid
+              JOIN {course} co
+                ON c.course = co.id
+              JOIN {user} u
+                ON ci.userid = u.id
+             WHERE ci.code = :code";
+
+        $records = $DB->get_record_sql($sql, ['code'=>$code]);
+
+        if (!$records){
+            // Return a Crippled array here. No more information than needed.
+            return array(
+                'validated' => False
+            );
+        }
+
+        return array(
+            'validated' => True,
+            'course_id' => $course->id,
+            'course_fullname' => $course->fullname,
+            'course_shortname' => $course->shortname,
+            'course_summary' => $course->summary,
+            'certificate_id' => $customcert->id,
+            'cert_issue_timestamp' => $customcert->timecreated,
+            'student_id' => $records->userid,
+            'student_name' => $records->firstname . ' ' . $records->lastname
+        );
+    }
+}

--- a/db/services.php
+++ b/db/services.php
@@ -24,6 +24,14 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+$services =  array('CustomCertValidate' => array(
+                   'functions' => ('mod_customcert_validate_certificate'),
+                   'requiredcapability' => '',
+                   'restrictedusers' =>0,
+                   'enabled'=>1,
+));
+
+
 $functions = array(
     'mod_customcert_save_element' => array(
         'classname'   => 'mod_customcert\external',
@@ -41,4 +49,13 @@ $functions = array(
         'type'        => 'read',
         'ajax'        => true
     ),
+    'mod_customcert_validate_certificate' => array(
+        'classname' => 'mod_customcert\ValidateCertificate',
+        'methodname' => 'validate_certificate',
+        'classpath' => 'mod/customcert/classes/ws/ValidateCertificate.php',
+        'description' => 'Verify if received values are valid for a issued certificate',
+        'type' => 'read',
+
+    )
+
 );

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden.');
 
-$plugin->version   = 2016120515; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2016120517; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2016120500; // Requires this Moodle version (3.2).
 $plugin->cron      = 0; // Period for cron to check this module (secs).
 $plugin->component = 'mod_customcert';


### PR DESCRIPTION
This version supports certificate validation through Moodle WebService Support.

#### Function name: `mod_customcert_validate_certificate`

#### Required Params: `['context_id', 'code']`

#### Returns {"validated": False} when no certificate is found for the given context_id/code.

Returns the following fields when the certificate is Ok:
```
array(
    'validated' => True,
    'course_id' => $course->id,
    'course_fullname' => $course->fullname,
    'course_shortname' => $course->shortname,
    'course_summary' => $course->summary,
    'certificate_id' => $customcert->id,
    'cert_issue_timestamp' => $customcert->timecreated,
    'student_id' => $records->userid,
    'student_name' => $records->firstname . ' ' . $records->lastname
)
```
#### Possible Enhancements

 * Create MoodleTestCases and coverage;
 * Add user to the returned fields (Base 64);
 * Discuss if the webservice requirements should include or not User/Course/ModCertificate:VerifyAny requirements;
 * Put the verify_certificate method in a common .lib.php file to be reused by verify_certificate.php and the webservice. At this point, the code is smelling in the fault of DRY.