### PR TITLE
only getting users details who are enrolled within the course

### DIFF
--- a/classes/task/email_certificate_task.php
+++ b/classes/task/email_certificate_task.php
@@ -70,8 +70,7 @@ class email_certificate_task extends \core\task\scheduled_task {
 
                 // Get the person we are going to send this email on behalf of.
                 // Look through the teachers.
-                if ($teachers = get_users_by_capability($context, 'moodle/course:update', 'u.*', 'u.id ASC',
-                    '', '', '', '', false, true)) {
+                if ($teachers = get_enrolled_users($context, 'moodle/course:update')) {
                     $teachers = sort_by_roleassignment_authority($teachers, $context);
                     $userfrom = reset($teachers);
                 } else { // Ok, no teachers, use administrator name.


### PR DESCRIPTION
Hi markn86
We are currently deploying custom cert and during testing it was discovered that when emailing the certificate and with Email teachers = true, we would also email to admin support users (not System Admin) who had no enrolment within the course.

We have several system level roles with course:update permission allowed for users ( Admin Support Staff ). 
As you are getting users with that capability on a site level, they are included in the email list.
If we limit this to just enrolled users, it will only send to the required people for that course.

Any reason you used get_users_by_capability?

Cheers
Tristan