### PR TITLE
Fix ORA-00932 inconsistent datatypes

### DIFF
--- a/classes/task/email_certificate_task.php
+++ b/classes/task/email_certificate_task.php
@@ -59,7 +59,7 @@ class email_certificate_task extends \core\task\scheduled_task {
                     ON c.course = co.id
                  WHERE (c.emailstudents = :emailstudents
                         OR c.emailteachers = :emailteachers
-                        OR c.emailothers != '')";
+                        OR length(c.emailothers) >= 3)";
         if ($customcerts = $DB->get_records_sql($sql, array('emailstudents' => 1, 'emailteachers' => 1))) {
             // The renderers used for sending emails.
             $htmlrenderer = $PAGE->get_renderer('mod_customcert', 'email', 'htmlemail');


### PR DESCRIPTION
Fix ORA-00932 inconsistent datatypes error.  3 is the minimum email address length (a@b).