### PR TITLE
Fixed report fields for download

### DIFF
--- a/classes/report_table.php
+++ b/classes/report_table.php
@@ -86,7 +86,7 @@ class report_table extends \table_sql {
             $headers[] = get_string('file');
         }
 
-        if (has_capability('mod/customcert:manage', \context_module::instance($cm->id))) {
+        if (!$this->is_downloading() && has_capability('mod/customcert:manage', \context_module::instance($cm->id))) {
             $columns[] = 'actions';
             $headers[] = '';
         }
@@ -113,7 +113,11 @@ class report_table extends \table_sql {
     public function col_fullname($user) {
         global $OUTPUT;
 
-        return $OUTPUT->user_picture($user) . ' ' . fullname($user);
+        if (!$this->is_downloading()) {
+            return $OUTPUT->user_picture($user) . ' ' . fullname($user);
+        } else {
+            return fullname($user);
+        }
     }
 
     /**


### PR DESCRIPTION
This patch fixes report download, removing user pix and actions column from reports.