### PR TITLE
Added format_string() to My Certificates/downloads and Verify certification pages

### DIFF
--- a/classes/my_certificates_table.php
+++ b/classes/my_certificates_table.php
@@ -94,7 +94,7 @@ class my_certificates_table extends \table_sql {
      * @return string
      */
     public function col_name($certificate) {
-        return $certificate->name;
+        return format_string($certificate->name);
     }
 
     /**
@@ -104,7 +104,7 @@ class my_certificates_table extends \table_sql {
      * @return string
      */
     public function col_coursename($certificate) {
-        return $certificate->coursename;
+        return format_string($certificate->coursename);
     }
 
     /**

--- a/classes/output/verify_certificate_result.php
+++ b/classes/output/verify_certificate_result.php
@@ -73,8 +73,8 @@ class verify_certificate_result implements templatable, renderable {
             'course' => $result->courseid));
         $this->userfullname = fullname($result);
         $this->courseurl = new \moodle_url('/course/view.php', array('id' => $result->courseid));
-        $this->coursefullname = $result->coursefullname;
-        $this->certificatename = $result->certificatename;
+        $this->coursefullname = format_string($result->coursefullname);
+        $this->certificatename = format_string($result->certificatename);
     }
 
     /**
@@ -86,10 +86,10 @@ class verify_certificate_result implements templatable, renderable {
     public function export_for_template(\renderer_base $output) {
         $result = new \stdClass();
         $result->userprofileurl = $this->userprofileurl;
-        $result->userfullname = $this->userfullname;
-        $result->coursefullname = $this->coursefullname;
+        $result->userfullname = format_string($this->userfullname);
+        $result->coursefullname = format_string($this->coursefullname);
         $result->courseurl = $this->courseurl;
-        $result->certificatename = $this->certificatename;
+        $result->certificatename = format_string($this->certificatename);
 
         return $result;
     }

--- a/my_certificates.php
+++ b/my_certificates.php
@@ -41,11 +41,13 @@ require_login();
 
 // Check that we have a valid user.
 $user = \core_user::get_user($userid, '*', MUST_EXIST);
-
 // If we are viewing certificates that are not for the currently logged in user then do a capability check.
 if (($userid != $USER->id) && !has_capability('mod/customcert:viewallcertificates', context_system::instance())) {
     print_error('You are not allowed to view these certificates');
 }
+
+$PAGE->set_url($pageurl);
+$PAGE->set_context(context_user::instance($userid));
 
 // Check if we requested to download a certificate.
 if ($downloadcert) {
@@ -63,8 +65,6 @@ if ($table->is_downloading()) {
     exit();
 }
 
-$PAGE->set_url($pageurl);
-$PAGE->set_context(context_user::instance($userid));
 $PAGE->set_title(get_string('mycertificates', 'customcert'));
 $PAGE->set_pagelayout('standard');
 $PAGE->navigation->extend_for_user($user);


### PR DESCRIPTION
This fix addresses the issues described in project issue #197.

Please note that the following 2 lines from customcert/my_certificates.php also had to be moved up a few lines because Moodle was complaining that the $PAGE->context was not set when downloading the data from the My Certificates page:

    $PAGE->set_url($pageurl);
    $PAGE->set_context(context_user::instance($userid));

Let me know if you have any questions or concerns.

Best regards,

Michael Milette
