### PR TITLE
Added plaintext lang variants for email bodies and updated template

### DIFF
--- a/classes/output/email_certificate.php
+++ b/classes/output/email_certificate.php
@@ -102,11 +102,13 @@ class email_certificate implements \renderable, \templatable {
         if ($this->isstudent) {
             $data->emailgreeting = get_string('emailstudentgreeting', 'customcert', $this->userfullname);
             $data->emailbody = get_string('emailstudentbody', 'customcert', $info);
+            $data->emailbodyplaintext = get_string('emailstudentbodyplaintext', 'customcert', $info);
             $data->emailcertificatelink = new \moodle_url('/mod/customcert/view.php', array('id' => $this->cmid));
             $data->emailcertificatetext = get_string('emailstudentcertificatelinktext', 'customcert');
         } else {
             $data->emailgreeting = get_string('emailnonstudentgreeting', 'customcert');
             $data->emailbody = get_string('emailnonstudentbody', 'customcert', $info);
+            $data->emailbodyplaintext = get_string('emailnonstudentbodyplaintext', 'customcert', $info);
             $data->emailcertificatelink = new \moodle_url('/mod/customcert/view.php', array('id' => $this->cmid));
             $data->emailcertificatetext = get_string('emailnonstudentcertificatelinktext', 'customcert');
         }

--- a/lang/en/customcert.php
+++ b/lang/en/customcert.php
@@ -72,10 +72,12 @@ Please note: The elements are rendered in this order. The order can be changed b
 $string['elementwidth'] = 'Width';
 $string['elementwidth_help'] = 'Specify the width of the element - \'0\' means that there is no width constraint.';
 $string['emailnonstudentbody'] = 'Attached is the certificate \'{$a->certificatename}\' for \'{$a->userfullname}\' for the course \'{$a->coursefullname}\'.';
+$string['emailnonstudentbodyplaintext'] = 'Attached is the certificate \'{$a->certificatename}\' for \'{$a->userfullname}\' for the course \'{$a->coursefullname}\'.';
 $string['emailnonstudentcertificatelinktext'] = 'View certificate report';
 $string['emailnonstudentgreeting'] = 'Hi';
 $string['emailnonstudentsubject'] = '{$a->coursefullname}: {$a->certificatename}';
 $string['emailstudentbody'] = 'Attached is your certificate \'{$a->certificatename}\' for the course \'{$a->coursefullname}\'.';
+$string['emailstudentbodyplaintext'] = 'Attached is your certificate \'{$a->certificatename}\' for the course \'{$a->coursefullname}\'.';
 $string['emailstudentcertificatelinktext'] = 'View certificate';
 $string['emailstudentgreeting'] = 'Dear {$a}';
 $string['emailstudentsubject'] = '{$a->coursefullname}: {$a->certificatename}';

--- a/templates/email_certificate_text.mustache
+++ b/templates/email_certificate_text.mustache
@@ -27,18 +27,18 @@
 
     Context variables required for this template:
     * emailgreeting
-    * emailbody
+    * emailbodyplaintext
     * emailcertificatelink
     * emailcertificatelinktext
 
     Example context (json):
     {
         "emailgreeting": "Dear Angus MacGyver",
-        "emailbody": "Attached is your certificate 'The basics' for the course 'Survival as an '80s action hero'",
+        "emailbodyplaintext": "Attached is your certificate 'The basics' for the course 'Survival as an '80s action hero'",
         "emailcertificatelink": "http://yoursite.com/mod/customcert/view.php?id=4",
         "emailcertificatelinktext": "Certificate report"
     }
 }}
 {{{emailgreeting}}}
 
-{{{emailbody}}}
+{{{emailbodyplaintext}}}


### PR DESCRIPTION
This will allow for creating HTML emails whilst still retaining the ability to show a plaintext email without worrying about confusing HTML tags appearing