### PR TITLE
Resolves #90: Make text element obey line breaks

### DIFF
--- a/element/text/classes/element.php
+++ b/element/text/classes/element.php
@@ -68,7 +68,7 @@ class element extends \mod_customcert\element {
      */
     public function render($pdf, $preview, $user) {
         $courseid = \mod_customcert\element_helper::get_courseid($this->get_id());
-        $text = format_text($this->get_data(), FORMAT_HTML, ['context' => \context_course::instance($courseid)]);
+        $text = format_text($this->get_data(), FORMAT_MOODLE, ['context' => \context_course::instance($courseid)]);
         \mod_customcert\element_helper::render_content($pdf, $this, $text);
     }
 
@@ -82,7 +82,7 @@ class element extends \mod_customcert\element {
      */
     public function render_html() {
         $courseid = \mod_customcert\element_helper::get_courseid($this->get_id());
-        $text = format_text($this->get_data(), FORMAT_HTML, ['context' => \context_course::instance($courseid)]);
+        $text = format_text($this->get_data(), FORMAT_MOODLE, ['context' => \context_course::instance($courseid)]);
         return \mod_customcert\element_helper::render_html_content($this, $text);
     }
 


### PR DESCRIPTION
Not sure why we're using FORMAT_HTML but it looks like FORMAT_MOODLE resolves the issue of it displaying on one line