### PR TITLE
Reduce filesystem checks for temp folder

### DIFF
--- a/classes/task/email_certificate_task.php
+++ b/classes/task/email_certificate_task.php
@@ -148,14 +148,14 @@ class email_certificate_task extends \core\task\scheduled_task {
 
                 // Now, email the people we need to.
                 if ($issuedusers) {
+                    // Create a directory to store the PDF we will be sending.
+                    $tempdir = make_temp_directory('certificate/attachment');
+                    if (!$tempdir) {
+                        return false;
+                    }
+                    
                     foreach ($issuedusers as $user) {
                         $userfullname = fullname($user);
-
-                        // Create a directory to store the PDF we will be sending.
-                        $tempdir = make_temp_directory('certificate/attachment');
-                        if (!$tempdir) {
-                            return false;
-                        }
 
                         // Now, get the PDF.
                         $template = new \stdClass();


### PR DESCRIPTION
Move creating the temp directory out of the emailing for loop