### PR TITLE
Upgrade usage of Travis testing code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: false
+sudo: true
 
 cache:
   directories:
@@ -11,7 +11,8 @@ php:
  - 7.2
 
 addons:
- postgresql: 9.3
+ firefox: "47.0.1"
+ postgresql: "9.4"
 
 env:
  global:
@@ -23,8 +24,7 @@ env:
 before_install:
   - phpenv config-rm xdebug.ini
   - cd ../..
-  - composer selfupdate
-  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^1
+  - composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
 install:
@@ -33,9 +33,6 @@ install:
 script:
   - moodle-plugin-ci phplint
   - moodle-plugin-ci codechecker
-  - moodle-plugin-ci csslint
-  - moodle-plugin-ci shifter
-  - moodle-plugin-ci jshint
   - moodle-plugin-ci validate
   - moodle-plugin-ci phpunit
   - moodle-plugin-ci behat


### PR DESCRIPTION
In f640449a105c0ac0e3ab82fa504b2a8cdef0278d (see #88), Travis support has been added with [`moodle-plugin-ci`, version 1](https://github.com/blackboard-open-source/moodle-plugin-ci/tree/v1).

This pull request updates to version 2 of `moodle-plugin-ci`.

In addition to this, it introduces necessary/recommended changes for testing this plugin with Moodle 3.5 and the current version of Travis, according to the [`moodle-plugin-ci` v1 to v2 upgrade guide](https://blackboard-open-source.github.io/moodle-plugin-ci/UPGRADE-2.0.html), see the [`moodle-plugin-ci`](https://github.com/blackboard-open-source/moodle-plugin-ci) repository and the [change log](https://blackboard-open-source.github.io/moodle-plugin-ci/CHANGELOG.html).

This should bring plugin `mod_customcert` up to a more recent state. We (=Moodle team at Ulm University) have found that this closes a few linting bugs for us.

In addition to the changes made in this pull request, it may be advisable to review the change log and upgrade guide mentioned above (and the [diffs to `.travis.dist.yml`](https://github.com/blackboard-open-source/moodle-plugin-ci/commits/master/.travis.dist.yml)) in order to bring in more/changed testing features.