### PR TITLE
 #252 Privacy API update

### DIFF
--- a/tests/privacy_provider_test.php
+++ b/tests/privacy_provider_test.php
@@ -65,6 +65,57 @@ class mod_customcert_privacy_provider_testcase extends \core_privacy\tests\provi
     }
 
     /**
+     * Test for provider::get_users_in_context().
+     */
+    public function test_get_users_in_context() {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course();
+
+        // The customcert activity the user will have an issue from.
+        $customcert1 = $this->getDataGenerator()->create_module('customcert', ['course' => $course->id]);
+        $customcert2 = $this->getDataGenerator()->create_module('customcert', ['course' => $course->id]);
+
+        // Call get_users_in_context() when the customcert hasn't any user.
+        $cm = get_coursemodule_from_instance('customcert', $customcert1->id);
+        $cmcontext = context_module::instance($cm->id);
+        $userlist = new \core_privacy\local\request\userlist($cmcontext, 'mod_customcert');
+        provider::get_users_in_context($userlist);
+
+        // Check no user has been returned.
+        $this->assertCount(0, $userlist->get_userids());
+
+        // Create some users who will be issued a certificate.
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $user3 = $this->getDataGenerator()->create_user();
+        $this->create_certificate_issue($customcert1->id, $user1->id);
+        $this->create_certificate_issue($customcert1->id, $user2->id);
+        $this->create_certificate_issue($customcert2->id, $user3->id);
+
+        // Call get_users_in_context() again.
+        provider::get_users_in_context($userlist);
+
+        // Check this time there are 2 users.
+        $this->assertCount(2, $userlist->get_userids());
+        $this->assertContains($user1->id, $userlist->get_userids());
+        $this->assertContains($user2->id, $userlist->get_userids());
+        $this->assertNotContains($user3->id, $userlist->get_userids());
+    }
+
+    /**
+     * Test for provider::get_users_in_context() with invalid context type.
+     */
+    public function test_get_users_in_context_invalid_context_type() {
+        $systemcontext = context_system::instance();
+
+        $userlist = new \core_privacy\local\request\userlist($systemcontext, 'mod_customcert');
+        \mod_customcert\privacy\provider::get_users_in_context($userlist);
+
+        $this->assertCount(0, $userlist->get_userids());
+    }
+
+    /**
      * Test for provider::export_user_data().
      */
     public function test_export_for_context() {
@@ -177,6 +228,52 @@ class mod_customcert_privacy_provider_testcase extends \core_privacy\tests\provi
         $this->assertCount(1, $customcertissue);
         $lastissue = reset($customcertissue);
         $this->assertEquals($user2->id, $lastissue->userid);
+    }
+
+    /**
+     * Test for provider::delete_data_for_users().
+     */
+    public function test_delete_data_for_users() {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        // Create course, customcert and users who will be issued a certificate.
+        $course = $this->getDataGenerator()->create_course();
+        $customcert1 = $this->getDataGenerator()->create_module('customcert', array('course' => $course->id));
+        $customcert2 = $this->getDataGenerator()->create_module('customcert', array('course' => $course->id));
+        $cm1 = get_coursemodule_from_instance('customcert', $customcert1->id);
+        $cm2 = get_coursemodule_from_instance('customcert', $customcert2->id);
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $user3 = $this->getDataGenerator()->create_user();
+        $this->create_certificate_issue($customcert1->id, $user1->id);
+        $this->create_certificate_issue($customcert1->id, $user2->id);
+        $this->create_certificate_issue($customcert1->id, $user3->id);
+        $this->create_certificate_issue($customcert2->id, $user1->id);
+        $this->create_certificate_issue($customcert2->id, $user2->id);
+
+        // Before deletion we should have 3 + 2 issued certificates.
+        $count = $DB->count_records('customcert_issues', ['customcertid' => $customcert1->id]);
+        $this->assertEquals(3, $count);
+        $count = $DB->count_records('customcert_issues', ['customcertid' => $customcert2->id]);
+        $this->assertEquals(2, $count);
+
+        $context1 = context_module::instance($cm1->id);
+        $approveduserlist = new \core_privacy\local\request\approved_userlist($context1, 'customcert',
+                [$user1->id, $user2->id]);
+        provider::delete_data_for_users($approveduserlist);
+
+        // After deletion, the customcert of the 2 students provided above should have been deleted
+        // from the activity. So there should only remain 1 certificate which is for $user3.
+        $customcertissues1 = $DB->get_records('customcert_issues', ['customcertid' => $customcert1->id]);
+        $this->assertCount(1, $customcertissues1);
+        $lastissue = reset($customcertissues1);
+        $this->assertEquals($user3->id, $lastissue->userid);
+
+        // Confirm that the certificates issues in the other activity are intact.
+        $customcertissues1 = $DB->get_records('customcert_issues', ['customcertid' => $customcert2->id]);
+        $this->assertCount(2, $customcertissues1);
     }
 
     /**


### PR DESCRIPTION
Add support to get_users_in_context and delete_data_for_users methods
added since 3.4.6 and 3.5.3 and 3.6.

This issue should help to fix https://github.com/markn86/moodle-mod_customcert/issues/252