### PR TITLE
UI improvements: spacing in web page, move table of issued certificates to separate page

### DIFF
--- a/classes/report_table.php
+++ b/classes/report_table.php
@@ -169,6 +169,7 @@ class report_table extends \table_sql {
             [
                 'id' => $this->cm->id,
                 'deleteissue' => $user->issueid,
+                'listissues' => true,
                 'sesskey' => sesskey()
             ]
         );

--- a/lang/en/customcert.php
+++ b/lang/en/customcert.php
@@ -109,6 +109,7 @@ $string['landscape'] = 'Landscape';
 $string['leftmargin'] = 'Left margin';
 $string['leftmargin_help'] = 'This is the left margin of the certificate PDF in mm.';
 $string['listofissues'] = 'Recipients';
+$string['listofissueslink'] = 'List of issued certificates';
 $string['load'] = 'Load';
 $string['loadtemplate'] = 'Load template';
 $string['loadtemplatemsg'] = 'Are you sure you wish to load this template? This will remove any existing pages and elements for this certificate.';

--- a/tests/behat/view_issued_certificates.feature
+++ b/tests/behat/view_issued_certificates.feature
@@ -22,7 +22,7 @@ Feature: Being able to view the certificates that have been issued
       | activity   | name                 | intro                      | course | idnumber    |
       | customcert | Custom certificate 1 | Custom certificate 1 intro | C1     | customcert1 |
 
-  Scenario: View the issued certificates
+  Scenario: View the issued certificates on a dedicated page
     And I log in as "student1"
     And I am on "Course 1" course homepage
     And I follow "Custom certificate 1"
@@ -36,9 +36,14 @@ Feature: Being able to view the certificates that have been issued
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
     And I follow "Custom certificate 1"
+    And I should see "View certificate"
+    And I should not see "Student 1"
+    And I should not see "Student 2"
     And I follow "List of issued certificates"
+    And I should not see "View certificate"
     And I should see "Student 1"
     And I should see "Student 2"
+    And I should not see "List of issued certificates"
 
   Scenario: Delete an issued certificate
     And I log in as "student1"

--- a/tests/behat/view_issued_certificates.feature
+++ b/tests/behat/view_issued_certificates.feature
@@ -36,6 +36,7 @@ Feature: Being able to view the certificates that have been issued
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
     And I follow "Custom certificate 1"
+    And I follow "List of issued certificates"
     And I should see "Student 1"
     And I should see "Student 2"
 
@@ -53,6 +54,7 @@ Feature: Being able to view the certificates that have been issued
     And I log in as "teacher1"
     And I am on "Course 1" course homepage
     And I follow "Custom certificate 1"
+    And I follow "List of issued certificates"
     And I should see "Student 1"
     And I should see "Student 2"
     And I click on ".delete-icon" "css_element" in the "Student 2" "table_row"

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden.');
 
-$plugin->version   = 2018120301; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2019011500; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2018120300; // Requires this Moodle version (3.6).
 $plugin->cron      = 0; // Period for cron to check this module (secs).
 $plugin->component = 'mod_customcert';

--- a/view.php
+++ b/view.php
@@ -137,6 +137,7 @@ if (!$downloadown && !$downloadissue) {
     $linkname = get_string('getcustomcert', 'customcert');
     $link = new moodle_url('/mod/customcert/view.php', array('id' => $cm->id, 'downloadown' => true));
     $downloadbutton = new single_button($link, $linkname, 'post', true);
+    $downloadbutton->class .= ' m-b-1';  // Seems a bit hackish, ahem.
     $downloadbutton = $OUTPUT->render($downloadbutton);
 
     // Output all the page data.


### PR DESCRIPTION
At Ulm University, we have improved the UI of this plugin a bit. This pull request contains two small changes:

1. Add a bit of spacing between the button for certificate generation (“View certificate”) and the heading. The page looks nicer then.
2. Move the list of issued certificates to a separate web page. As the list can grow quite long, we like to keep it separate. We have adjusted and added to the Behat test so that it can automatically verify that we have not broken anything.

This code can also be used on top of branch `MOODLE_35_STABLE`.