### PR TITLE
Create catalyst-ci

### DIFF
--- a/.github/workflows/catalyst-ci
+++ b/.github/workflows/catalyst-ci
@@ -1,0 +1,15 @@
+# .github/workflows/ci.yml
+name: catalyst-ci
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 1 * *' # Runs every month to see if a new version of Moodle was released
+
+jobs:
+  ci:
+    uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+    # Required if you plan to publish (uncomment the below)
+    # secrets:
+      # moodle_org_token: ${{ secrets.MOODLE_ORG_TOKEN }}


### PR DESCRIPTION
This PR tries to implement a best practice documented here https://github.com/fulldecent/moodle-local_plugin_template/blob/main/.github/workflows/ci.yml

---

We would like to automatically test this plug-in every month by automatically looking for the latest stable version of Moodle.

This will allow us to achieve 4.5, 5.0 and 5.1 compatibility, possibly in our sleep.

---

Personally, I think the Moodle maintainer leadership [is derelict](https://tracker.moodle.org/browse/MDLSITE-8072) in making this so difficult for our plug-in here and the millions of other plug-ins to stay up-to-date. So I think best practice today is to use a level of indirection like I am showing in this PR and I'm documenting in our best practices repo.