### PR TITLE
Fix implicit ordering in test_email_certificates_sitehome #715

### DIFF
--- a/tests/email_certificate_task_test.php
+++ b/tests/email_certificate_task_test.php
@@ -282,14 +282,15 @@ final class email_certificate_task_test extends advanced_testcase {
             $this->assertEquals(1, $issue->emailed);
         }
 
-        // Confirm that we sent out emails to the two users.
+        // Confirm that we sent out emails to the users. This includes the site admin.
         $this->assertCount(3, $emails);
+        $expectedemails = [get_admin()->email, $user1->email, $user2->email];
 
-        $this->assertEquals($CFG->noreplyaddress, $emails[1]->from);
-        $this->assertEquals($user1->email, $emails[1]->to);
-
-        $this->assertEquals($CFG->noreplyaddress, $emails[2]->from);
-        $this->assertEquals($user2->email, $emails[2]->to);
+        foreach ($emails as $email) {
+            $this->assertEquals($CFG->noreplyaddress, $email->from);
+            $this->assertContains($email->to, $expectedemails);
+            $expectedemails = array_diff($expectedemails, [$email->to]);
+        }
 
         // Now, run the task again and ensure we did not issue any more certificates.
         $sink = $this->redirectEmails();


### PR DESCRIPTION
The site home course has all users enrolled, including the site admin. 

The options here were excluding admins from the test by assigning them the manager role or including them in the test. I went with the latter as it makes the expected behavior more obvious, but happy to swap to another approach.

Closes #715 