### PR TITLE
feat: activity completion when certificate is issued via email

### DIFF
--- a/classes/completion/custom_completion.php
+++ b/classes/completion/custom_completion.php
@@ -1,0 +1,106 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Activity custom completion class for mod_customcert.
+ *
+ * @package    mod_customcert
+ * @copyright  2026 Vadym Nersesov
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace mod_customcert\completion;
+
+use core_completion\activity_custom_completion;
+
+/**
+ * Activity custom completion class for mod_customcert.
+ *
+ * Evaluates the "completionissued" rule: marks the activity complete when a
+ * certificate has been emailed to the student.
+ *
+ * @package    mod_customcert
+ * @copyright  2026 Vadym Nersesov
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class custom_completion extends activity_custom_completion {
+
+    /**
+     * Fetches the completion state for a given completion rule.
+     *
+     * @param string $rule The completion rule.
+     * @return int The completion state (COMPLETION_COMPLETE or COMPLETION_INCOMPLETE).
+     */
+    public function get_state(string $rule): int {
+        global $DB;
+
+        $this->validate_rule($rule);
+
+        $customcertid = $this->cm->instance;
+        $userid = $this->userid;
+
+        if ($rule === 'completionissued') {
+            $customcert = $DB->get_record('customcert', ['id' => $customcertid], 'id, completionissued, emailstudents',
+                MUST_EXIST);
+
+            // Rule is active only when email to students is enabled (globally or per-instance).
+            if (empty($customcert->emailstudents) && !get_config('customcert', 'emailstudents')) {
+                return COMPLETION_INCOMPLETE;
+            }
+
+            $emailed = $DB->record_exists('customcert_issues',
+                ['customcertid' => $customcertid, 'userid' => $userid, 'emailed' => 1]);
+
+            return $emailed ? COMPLETION_COMPLETE : COMPLETION_INCOMPLETE;
+        }
+
+        return COMPLETION_INCOMPLETE;
+    }
+
+    /**
+     * Fetch the list of custom completion rules that this module defines.
+     *
+     * @return array
+     */
+    public static function get_defined_custom_rules(): array {
+        return ['completionissued'];
+    }
+
+    /**
+     * Returns an associative array of the descriptions of the custom completion rules.
+     *
+     * @return array
+     */
+    public function get_custom_rule_descriptions(): array {
+        return [
+            'completionissued' => get_string('completionissued', 'customcert'),
+        ];
+    }
+
+    /**
+     * Returns an array of all completion rules, in the order they should be displayed to users.
+     *
+     * @return array
+     */
+    public function get_sort_order(): array {
+        return [
+            'completionview',
+            'completionissued',
+        ];
+    }
+}

--- a/classes/task/completion_backfill_task.php
+++ b/classes/task/completion_backfill_task.php
@@ -1,0 +1,116 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * An adhoc task to backfill activity completion for existing automatically issued certificates.
+ *
+ * @package    mod_customcert
+ * @copyright  2026 Vadym Nersesov
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace mod_customcert\task;
+
+/**
+ * Backfills activity completion for users who already received a certificate via the scheduled task.
+ *
+ * For every customcert instance where emailstudents is enabled, this task:
+ *  - Sets completionissued = 1 (retroactive opt-in, since email was already active).
+ *  - Marks activity completion for users whose certificate was already emailed.
+ *
+ * This task is queued automatically during the plugin upgrade to 2024042219.
+ *
+ * @package    mod_customcert
+ * @copyright  2026 Vadym Nersesov
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class completion_backfill_task extends \core\task\adhoc_task {
+
+    /**
+     * Get a descriptive name for this task.
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('taskcompletionbackfill', 'customcert');
+    }
+
+    /**
+     * Execute the backfill.
+     */
+    public function execute() {
+        global $DB;
+
+        mtrace('Starting activity completion backfill for mod_customcert...');
+
+        // Find all customcert instances where automatic email to students was enabled.
+        // These are the activities whose existing issued certs should receive completion.
+        $customcerts = $DB->get_records('customcert', ['emailstudents' => 1]);
+
+        $processed = 0;
+        $skipped = 0;
+
+        foreach ($customcerts as $customcert) {
+            // Retroactively opt this instance into completionissued if not already set.
+            if (empty($customcert->completionissued)) {
+                $DB->set_field('customcert', 'completionissued', 1, ['id' => $customcert->id]);
+                $customcert->completionissued = 1;
+            }
+
+            // Resolve course and course-module objects.
+            try {
+                [$course, $cm] = get_course_and_cm_from_instance($customcert->id, 'customcert', $customcert->course);
+            } catch (\Exception $e) {
+                debugging(
+                    'completion_backfill_task: could not resolve cm for customcert id=' . $customcert->id .
+                    ': ' . $e->getMessage(),
+                    DEBUG_DEVELOPER
+                );
+                $skipped++;
+                continue;
+            }
+
+            // Only set completion when the activity has completion tracking enabled.
+            $completioninfo = new \completion_info($course);
+            if (!$completioninfo->is_enabled($cm)) {
+                $skipped++;
+                continue;
+            }
+
+            // Find all users whose certificate was already emailed by the scheduled task.
+            $issues = $DB->get_records(
+                'customcert_issues',
+                ['customcertid' => $customcert->id, 'emailed' => 1],
+                '',
+                'userid'
+            );
+
+            foreach ($issues as $issue) {
+                try {
+                    $completioninfo->update_state($cm, COMPLETION_COMPLETE, $issue->userid);
+                    $processed++;
+                } catch (\Exception $e) {
+                    debugging(
+                        'completion_backfill_task: could not update completion for userid=' . $issue->userid .
+                        ' in customcert id=' . $customcert->id . ': ' . $e->getMessage(),
+                        DEBUG_DEVELOPER
+                    );
+                }
+            }
+        }
+
+        mtrace("Activity completion backfill complete. Processed: $processed, Skipped (no completion): $skipped.");
+    }
+}

--- a/classes/task/issue_certificates_task.php
+++ b/classes/task/issue_certificates_task.php
@@ -60,7 +60,8 @@ class issue_certificates_task extends \core\task\scheduled_task {
         }
 
         $emailotherslengthsql = $DB->sql_length('c.emailothers');
-        $sql = "SELECT DISTINCT c.id, c.templateid, c.course, c.requiredtime, c.emailstudents, c.emailteachers, $emailothersselect,
+        $sql = "SELECT DISTINCT c.id, c.templateid, c.course, c.requiredtime, c.emailstudents, c.emailteachers,
+                       c.completionissued, $emailothersselect,
                        ct.id AS templateid, ct.name AS templatename, ct.contextid, co.id AS courseid,
                        co.fullname AS coursefullname, co.shortname AS courseshortname
                   FROM {customcert} c
@@ -104,7 +105,7 @@ class issue_certificates_task extends \core\task\scheduled_task {
 
         foreach ($customcerts as $customcert) {
             // Check if the certificate is hidden, quit early.
-            $cm = get_course_and_cm_from_instance($customcert->id, 'customcert', $customcert->course)[1];
+            [$course, $cm] = get_course_and_cm_from_instance($customcert->id, 'customcert', $customcert->course);
             if (!$cm->visible) {
                 continue;
             }
@@ -199,6 +200,14 @@ class issue_certificates_task extends \core\task\scheduled_task {
                 } else {
                     $issueid = \mod_customcert\certificate::issue_certificate($customcert->id, $filtereduser->id);
                     $emailed = 0;
+                }
+
+                // Trigger activity completion when a certificate is issued, if the feature is enabled.
+                if (!empty($issueid) && !empty($customcert->completionissued)) {
+                    $completioninfo = new \completion_info($course);
+                    if ($completioninfo->is_enabled($cm)) {
+                        $completioninfo->update_state($cm, COMPLETION_COMPLETE, $filtereduser->id);
+                    }
                 }
 
                 // If we have an issue and it has not been emailed yet, send it now.

--- a/db/install.xml
+++ b/db/install.xml
@@ -20,6 +20,7 @@
         <FIELD NAME="emailstudents" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="emailteachers" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="emailothers" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="completionissued" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="protection" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="language" TYPE="char" LENGTH="20" NOTNULL="false" SEQUENCE="false" COMMENT="Force certificate to render with specified langauge"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -349,5 +349,20 @@ function xmldb_customcert_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2024042213, 'customcert');
     }
 
+    if ($oldversion < 2024042218) {
+        // Add 'completionissued' field to track completion when a certificate is emailed.
+        $table = new xmldb_table('customcert');
+        $field = new xmldb_field('completionissued', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'emailothers');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Queue an adhoc task to backfill completion state for existing issued certificates.
+        $task = new \mod_customcert\task\completion_backfill_task();
+        \core\task\manager::queue_adhoc_task($task, true);
+
+        upgrade_mod_savepoint(true, 2024042218, 'customcert');
+    }
+
     return true;
 }

--- a/lang/en/customcert.php
+++ b/lang/en/customcert.php
@@ -226,6 +226,7 @@ $string['showposxy_desc'] = 'This will show the X and Y position when editing of
 This isn\'t required if you plan on solely using the drag and drop interface for this purpose.';
 $string['subplugintype_customcertelement'] = 'Element';
 $string['subplugintype_customcertelement_plural'] = 'Elements';
+$string['taskcompletionbackfill'] = 'Backfill activity completion for existing issued certificates.';
 $string['taskemailcertificate'] = 'Handles emailing certificates.';
 $string['taskissuecertificate'] = 'Issue certificates task';
 $string['templatename'] = 'Template name';

--- a/lib.php
+++ b/lib.php
@@ -274,7 +274,6 @@ function customcert_supports($feature) {
         case FEATURE_SHOW_DESCRIPTION:
         case FEATURE_COMPLETION_TRACKS_VIEWS:
         case FEATURE_BACKUP_MOODLE2:
-        case FEATURE_GROUPS:
             return true;
         case FEATURE_MOD_PURPOSE:
             return MOD_PURPOSE_OTHER;

--- a/mod_form.php
+++ b/mod_form.php
@@ -139,6 +139,45 @@ class mod_customcert_mod_form extends moodleform_mod {
     }
 
     /**
+     * Add elements to form.
+     */
+    public function add_completion_rules() {
+        $mform =& $this->_form;
+
+        $mform->addElement('checkbox', 'completionissued', '', get_string('completionissued', 'customcert'));
+        $mform->setType('completionissued', PARAM_BOOL);
+        $mform->addHelpButton('completionissued', 'completionissued', 'customcert');
+
+        // Disable the completion checkbox if email to students is not enabled.
+        // Check if the user has permission to manage email students setting.
+        if (has_capability('mod/customcert:manageemailstudents', $this->get_context())) {
+            // If user can manage email students, disable completion when emailstudents is not checked.
+            $mform->disabledIf('completionissued', 'emailstudents', 'eq', 0);
+        } else {
+            // If user can't manage email students, check global setting.
+            $globalemailstudents = get_config('customcert', 'emailstudents');
+            if (!$globalemailstudents) {
+                // If global setting is disabled, disable the completion checkbox entirely.
+                $mform->addElement('static', 'completionissued_disabled_note', '',
+                    get_string('completionissuedemailerror', 'customcert'));
+                $mform->setConstant('completionissued', 0);
+            }
+        }
+
+        return ['completionissued'];
+    }
+
+    /**
+     * Called during validation. Indicates whether a module-specific completion rule is selected.
+     *
+     * @param array $data Input data (not yet validated)
+     * @return bool True if one or more rules is enabled, false if none are.
+     */
+    public function completion_rule_enabled($data) {
+        return (!empty($data['completionissued']));
+    }
+
+    /**
      * Any data processing needed before the form is displayed.
      *
      * @param array $defaultvalues

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden.');
 
-$plugin->version   = 2024042217; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2024042218; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2024042200; // Requires this Moodle version (4.4).
 $plugin->cron      = 0; // Period for cron to check this module (secs).
 $plugin->component = 'mod_customcert';


### PR DESCRIPTION
Closes #645

Adds a new custom completion rule "Receive a certificate" (`completionissued`) that automatically marks the activity complete when a certificate is emailed to the student via the scheduled task.

**Changes:**
- `classes/completion/custom_completion.php` — Moodle 4.x `activity_custom_completion` API implementation
- `classes/task/completion_backfill_task.php` — adhoc task to retroactively set completion for users who already received a certificate
- `classes/task/issue_certificates_task.php` — triggers completion after certificate issuance
- `db/install.xml`, `db/upgrade.php` — adds `completionissued` field to `mdl_customcert`
- `lib.php` — declares `FEATURE_COMPLETION_HAS_RULES`
- `mod_form.php` — adds checkbox to activity settings, disabled when "Email students" is off
- `lang/en/customcert.php` — new strings

Happy to provide branches for MOODLE_500_STABLE / main if needed.