### PR TITLE
Fix get_date_format_string type hint to accept legacy int dateformat

### DIFF
--- a/classes/element_helper.php
+++ b/classes/element_helper.php
@@ -810,10 +810,10 @@ class element_helper {
      * Returns the date in a readable format.
      *
      * @param int $date
-     * @param string $dateformat
+     * @param string|int $dateformat
      * @return string
      */
-    public static function get_date_format_string(int $date, string $dateformat): string {
+    public static function get_date_format_string(int $date, string|int $dateformat): string {
         // Keeping for backwards compatibility.
         if (is_number($dateformat)) {
             switch ($dateformat) {

--- a/tests/element_helper_test.php
+++ b/tests/element_helper_test.php
@@ -454,4 +454,27 @@ final class element_helper_test extends advanced_testcase {
             $this->assertIsInt($value);
         }
     }
+
+    /**
+     * get_date_format_string accepts an int $dateformat for backwards
+     * compatibility with pre-5.2 customcert_elements data (where dateformat
+     * was stored as an int constant). The function body already handles this
+     * via is_number($dateformat); the strict 'string' type hint previously
+     * rejected such calls with a TypeError before the backwards-compat branch
+     * could run, breaking PDF generation on legacy data.
+     *
+     * @covers \mod_customcert\element_helper::get_date_format_string
+     */
+    public function test_get_date_format_string_accepts_int_dateformat_for_backwards_compat(): void {
+        $date = mktime(0, 0, 0, 6, 15, 2024);
+
+        // Both int and string-of-digit dateformat must be accepted and produce identical output.
+        $fromint = element_helper::get_date_format_string($date, 1);
+        $fromstr = element_helper::get_date_format_string($date, '1');
+
+        $this->assertIsString($fromint);
+        $this->assertIsString($fromstr);
+        $this->assertNotEmpty($fromint);
+        $this->assertSame($fromstr, $fromint);
+    }
 }


### PR DESCRIPTION
## Problem

`\mod_customcert\element_helper::get_date_format_string()` declares `string $dateformat`, but the function body explicitly handles `int` via `is_number($dateformat)` for backwards compatibility:

```php
public static function get_date_format_string(int $date, string $dateformat): string {
    // Keeping for backwards compatibility.
    if (is_number($dateformat)) {
        switch ($dateformat) {
            case 1:
                $certificatedate = userdate($date, '%B %d, %Y');
                break;
            case 2:
                ...
```

The strict `string` type hint rejects any int caller with a `TypeError` **before** the backwards-compat branch can run, so that branch is currently unreachable.

## Impact

Existing sites often have pre-5.2 `customcert_elements` rows whose JSON `data` carries an int dateformat:

```json
{"dateitem": "-2", "dateformat": 1, "width": 297, ...}
```

v5.2.0 ships no migration converting these to string, so on upgrade the first PDF render of any template containing a date or expiry element with legacy data throws:

```
mod_customcert\element_helper::get_date_format_string(): Argument #2 ($dateformat) must be of type string, int given,
called in [dirroot]/mod/customcert/element/date/classes/element.php on line 265
```

All four call sites are affected on legacy data:
- `element/date/classes/element.php:265`
- `element/date/classes/element.php:293`
- `element/expiry/classes/element.php:204`
- `element/expiry/classes/element.php:251`

## Fix

Widen the `$dateformat` parameter type to `string|int` so the existing `is_number($dateformat)` backwards-compat path is reachable again. Moodle 5.2 requires PHP 8.1+, so PHP 8.0 union types are available. No caller-side change required.

## Test

Added a regression test in `tests/element_helper_test.php` asserting that both `1` (int) and `"1"` (string) produce the same non-empty output and do not throw.

## Verified on

- Moodle 5.2+ (Build: 20260525) running mod_customcert v5.2.0
- 3 legacy date elements in `customcert_elements` with `"dateformat": 1`
- **Before patch:** `TypeError` on every PDF render.
- **After patch:** valid PDF (`%PDF-` header, ~165 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)