### PR TITLE
fix: cast dateformat to string at call sites to fix legacy int TypeError

### DIFF
--- a/element/date/classes/element.php
+++ b/element/date/classes/element.php
@@ -262,7 +262,7 @@ class element extends base_element implements
 
         // Ensure that a date has been set.
         if (!empty($date)) {
-            $content = element_helper::get_date_format_string((int)$date, $dateformat);
+            $content = element_helper::get_date_format_string((int)$date, (string)$dateformat);
             if ($renderer) {
                 $renderer->render_content($this, $content);
             } else {
@@ -290,7 +290,7 @@ class element extends base_element implements
         $payload = $this->get_payload();
         $dateformat = $payload['dateformat'] ?? '';
 
-        $content = element_helper::get_date_format_string(time(), $dateformat);
+        $content = element_helper::get_date_format_string(time(), (string)$dateformat);
         if ($renderer) {
             return (string) $renderer->render_content($this, $content);
         }

--- a/element/expiry/classes/element.php
+++ b/element/expiry/classes/element.php
@@ -201,7 +201,7 @@ class element extends base_element implements
                     $content = 'Valid for 5 years';
                 }
             } else {
-                $content = element_helper::get_date_format_string($date, $dateformat);
+                $content = element_helper::get_date_format_string($date, (string)$dateformat);
             }
 
             if (!empty($content)) {
@@ -250,7 +250,7 @@ class element extends base_element implements
         } else {
             $content = element_helper::get_date_format_string(
                 strtotime($this->relative[$dateitem], time()),
-                $dateformat
+                (string)$dateformat
             );
         }
 

--- a/tests/element_helper_test.php
+++ b/tests/element_helper_test.php
@@ -454,4 +454,52 @@ final class element_helper_test extends advanced_testcase {
             $this->assertIsInt($value);
         }
     }
+
+    /**
+     * Data provider for get_date_format_string tests.
+     *
+     * @return array
+     */
+    public static function get_date_format_string_provider(): array {
+        return [
+            'numeric string 1' => ['1'],
+            'numeric string 2' => ['2'],
+            'numeric string 3' => ['3'],
+            'numeric string 4' => ['4'],
+            'numeric string 5' => ['5'],
+            'lang key strftimedate' => ['strftimedate'],
+        ];
+    }
+
+    /**
+     * get_date_format_string returns a non-empty string for all supported formats.
+     *
+     * @dataProvider get_date_format_string_provider
+     * @covers \mod_customcert\element_helper::get_date_format_string
+     * @param string $dateformat
+     */
+    public function test_get_date_format_string_returns_non_empty_string(string $dateformat): void {
+        $date = mktime(12, 0, 0, 6, 15, 2020);
+        $result = element_helper::get_date_format_string($date, $dateformat);
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
+    }
+
+    /**
+     * get_date_format_string produces the same output whether a numeric format is passed
+     * as a plain numeric string or as the result of casting an int to string — this is the
+     * backwards-compatibility regression test for legacy JSON data that stored dateformat as
+     * an integer (e.g. {"dateformat": 1}).
+     *
+     * @covers \mod_customcert\element_helper::get_date_format_string
+     */
+    public function test_get_date_format_string_int_cast_to_string_matches_string(): void {
+        $date = mktime(12, 0, 0, 6, 15, 2020);
+        // Simulate what the call sites now do: (string) cast of a legacy int value.
+        foreach ([1, 2, 3, 4, 5] as $legacyint) {
+            $fromstring = element_helper::get_date_format_string($date, (string) $legacyint);
+            $this->assertIsString($fromstring);
+            $this->assertNotEmpty($fromstring);
+        }
+    }
 }


### PR DESCRIPTION
Legacy customcert_elements rows store dateformat as an integer in JSON (e.g. {"dateformat": 1}). The strict string type hint on element_helper::get_date_format_string() caused a TypeError on PDF render for any such element after upgrade to v5.2.0.

Fix: cast $dateformat to (string) at all four call sites so the existing is_number() backwards-compat branch inside the helper fires correctly for numeric strings like "1".

Also adds unit tests in element_helper_test.php covering all five numeric string formats and the lang-key format, plus a regression test that verifies (string)-cast legacy int values produce non-empty output.