### PR TITLE
Security release 4.4.12: missing capability checks and issuance-existence validation

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -73,8 +73,7 @@ jobs:
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8
-          # Install nvm v0.39.7 (temp workaround for issue https://github.com/moodlehq/moodle-plugin-ci/issues/309).
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+          echo NVM_DIR=$HOME/.nvm >> $GITHUB_ENV
 
       - name: Install moodle-plugin-ci
         run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -12,21 +12,32 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13
+        image: postgres:16
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
         ports:
           - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+
       mariadb:
-        image: mariadb:10.6.10
+        image: mariadb:10.11
         env:
           MYSQL_USER: 'root'
-          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
+          MYSQL_CHARACTER_SET_SERVER: 'utf8mb4'
+          MYSQL_COLLATION_SERVER: 'utf8mb4_unicode_ci'
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -99,52 +99,52 @@ jobs:
           MUSTACHE_IGNORE_NAMES: 'mobile_*.mustache'
 
       - name: PHP Lint
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: moodle-plugin-ci phplint
 
       - name: PHP Copy/Paste Detector
-        continue-on-error: true # This step will show errors but will not fail
-        if: ${{ always() }}
+        continue-on-error: true
+        if: ${{ !cancelled() }}
         run: moodle-plugin-ci phpcpd
 
       - name: PHP Mess Detector
-        continue-on-error: true # This step will show errors but will not fail
-        if: ${{ always() }}
+        continue-on-error: true
+        if: ${{ !cancelled() }}
         run: moodle-plugin-ci phpmd
 
-      - name: Moodle Code Checker
-        if: ${{ always() }}
-        run: moodle-plugin-ci codechecker --max-warnings 0
+      - name: Moodle CodeSniffer
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcs --max-warnings 0
 
       - name: Moodle PHPDoc Checker
-        if: ${{ always() }}
-        run: moodle-plugin-ci phpdoc
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpdoc --max-warnings 0
 
       - name: Validating
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: moodle-plugin-ci validate
 
       - name: Check upgrade savepoints
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: moodle-plugin-ci savepoints
 
       - name: Mustache Lint
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: moodle-plugin-ci mustache
 
       - name: Grunt
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: moodle-plugin-ci grunt --max-lint-warnings 0
 
       - name: PHPUnit tests
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: |
-          moodle-plugin-ci phpunit
+          moodle-plugin-ci phpunit --fail-on-risky
           cd moodle
           vendor/bin/phpunit --fail-on-risky --disallow-test-output --filter tool_dataprivacy_metadata_registry_testcase
           vendor/bin/phpunit --fail-on-risky --disallow-test-output --filter core_externallib_testcase
           vendor/bin/phpunit --fail-on-risky --disallow-test-output --testsuite core_privacy_testsuite --filter provider_testcase
 
       - name: Behat features
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         run: moodle-plugin-ci behat --profile chrome

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -2,8 +2,12 @@ name: Moodle Plugin CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    name: PHP ${{ matrix.php }} / ${{ matrix.moodle-branch }} / ${{ matrix.database }}
     runs-on: ubuntu-22.04
 
     services:
@@ -56,7 +60,7 @@ jobs:
             database: mariadb
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: plugin
 
@@ -64,6 +68,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: intl, mbstring, mysqli, pgsql, pdo_mysql, pdo_pgsql, soap, zip, gd, exif, sodium
           ini-values: max_input_vars=5000
           coverage: none
 

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -145,6 +145,46 @@ jobs:
           vendor/bin/phpunit --fail-on-risky --disallow-test-output --filter core_externallib_testcase
           vendor/bin/phpunit --fail-on-risky --disallow-test-output --testsuite core_privacy_testsuite --filter provider_testcase
 
+      - name: PHPUnit tests for subplugins
+        if: ${{ !cancelled() }}
+        run: |
+          fail=0
+          failures=()
+          for base in $(jq -r '.subplugintypes[]' ./plugin/db/subplugins.json); do
+            for dir in $(find "./plugin/$base" -mindepth 1 -maxdepth 1 -type d); do
+              if [ -d "$dir/tests" ]; then
+                echo "Running PHPUnit for $dir"
+                if moodle-plugin-ci phpunit --fail-on-risky "$dir"; then
+                  echo "OK: $dir"
+                else
+                  rc=$?
+                  echo "WARNING: PHPUnit failed for $dir (rc=$rc)"
+                  failures+=("$dir: returncode: $rc")
+                  fail=1
+                fi
+              fi
+            done
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "Some PHPUnit runs failed:"
+            printf '%s\n' "${failures[@]}"
+            exit 1
+          fi
+
       - name: Behat features
+        id: behat
         if: ${{ !cancelled() }}
         run: moodle-plugin-ci behat --profile chrome
+
+      - name: Upload Behat faildump
+        if: ${{ failure() && steps.behat.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Behat faildump (${{ matrix.php }}, ${{ matrix.moodle-branch }}, ${{ matrix.database }})
+          path: ${{ github.workspace }}/moodledata/behat_dump
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Mark cancelled jobs as failed
+        if: ${{ cancelled() }}
+        run: exit 1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 Note - All hash comments refer to the issue number. Eg. #169 refers to https://github.com/mdjnelson/moodle-mod_customcert/issues/169.
 
+## [4.4.12] - 2026-08-10
+
+### Security
+
+- Added a missing capability check so that only users who can manage a certificate template can fetch element HTML or the admin edit-element form via `get_element_html()` and the `editelement` fragment callback (#869).
+- `view.php`'s report-download flow (`downloadissue`) now verifies the target user has actually been issued the certificate before generating a PDF for them, preventing a report-viewer from generating a certificate for an arbitrary user who was never issued one (#869).
+- Moved the login check in `my_certificates.php` above the certificate-issuance existence check, preventing an unauthenticated user from probing whether a given user has been issued a given certificate (#869).
+
 ## [4.4.11] - 2026-08-02
 
 ### Security

--- a/classes/external.php
+++ b/classes/external.php
@@ -166,6 +166,9 @@ class external extends external_api {
             self::validate_context(\context_system::instance());
         }
 
+        // Only users who can manage this template may fetch its element HTML.
+        $template->require_manage();
+
         // Verify the element belongs to the given template to prevent cross-template information disclosure.
         $page = $DB->get_record('customcert_pages', ['id' => $element->pageid], '*', MUST_EXIST);
         if ($page->templateid != $templateid) {

--- a/lib.php
+++ b/lib.php
@@ -327,6 +327,9 @@ function mod_customcert_output_fragment_editelement($args) {
         throw new \moodle_exception('Invalid access');
     }
 
+    // Only users who can manage this template may view the admin edit-element form.
+    (new \mod_customcert\template($template))->require_manage();
+
     $pageurl = new moodle_url('/mod/customcert/rearrange.php', ['pid' => $element->pageid]);
     $form = new \mod_customcert\edit_element_form($pageurl, ['element' => $element]);
 

--- a/my_certificates.php
+++ b/my_certificates.php
@@ -28,6 +28,15 @@ $userid = optional_param('userid', $USER->id, PARAM_INT);
 $download = optional_param('download', null, PARAM_ALPHA);
 $courseid = optional_param('course', null, PARAM_INT);
 $downloadcert = optional_param('downloadcert', '', PARAM_BOOL);
+
+// Requires a login. This must happen before any data-dependent checks below, so that
+// an unauthenticated request cannot be used to probe certificate-issuance existence.
+if ($courseid) {
+    require_login($courseid);
+} else {
+    require_login();
+}
+
 if ($downloadcert) {
     $certificateid = required_param('certificateid', PARAM_INT);
     $customcert = $DB->get_record('customcert', ['id' => $certificateid], '*', MUST_EXIST);
@@ -41,13 +50,6 @@ $page = optional_param('page', 0, PARAM_INT);
 $perpage = optional_param('perpage', \mod_customcert\certificate::CUSTOMCERT_PER_PAGE, PARAM_INT);
 $pageurl = $url = new moodle_url('/mod/customcert/my_certificates.php', ['userid' => $userid,
     'page' => $page, 'perpage' => $perpage]);
-
-// Requires a login.
-if ($courseid) {
-    require_login($courseid);
-} else {
-    require_login();
-}
 
 // Check that we have a valid user.
 $user = \core_user::get_user($userid, '*', MUST_EXIST);

--- a/tests/behat/behat_mod_customcert.php
+++ b/tests/behat/behat_mod_customcert.php
@@ -162,4 +162,29 @@ class behat_mod_customcert extends behat_base {
         $url = new moodle_url('/mod/customcert/verify_certificate.php');
         $this->getSession()->visit($this->locate_path($url->out_as_local_url()));
     }
+
+    /**
+     * Directs the current (possibly logged-out) user to the personal certificate download URL
+     * for another user.
+     *
+     * Used to test that the certificate-issuance existence check cannot be probed before the
+     * caller is authenticated.
+     *
+     * phpcs:ignore
+     * @Given /^I attempt to download the personal certificate PDF for "(?P<user_name>(?:[^"]|\\")*)" in "(?P<certificate_name>(?:[^"]|\\")*)"$/
+     * @param string $username
+     * @param string $certificatename
+     */
+    public function i_attempt_to_download_the_personal_certificate_pdf_for($username, $certificatename) {
+        global $DB;
+
+        $certificate = $DB->get_record('customcert', ['name' => $certificatename], '*', MUST_EXIST);
+        $user = $DB->get_record('user', ['username' => $username], '*', MUST_EXIST);
+
+        $url = new moodle_url(
+            '/mod/customcert/my_certificates.php',
+            ['downloadcert' => 1, 'certificateid' => $certificate->id, 'userid' => $user->id]
+        );
+        $this->getSession()->visit($this->locate_path($url->out_as_local_url(false)));
+    }
 }

--- a/tests/behat/download_authorisation.feature
+++ b/tests/behat/download_authorisation.feature
@@ -1,0 +1,25 @@
+@mod @mod_customcert
+Feature: Certificate downloads verify issuance before generating a PDF
+  In order to prevent certificate data being generated for the wrong user
+  As a developer
+  I need personal-download requests to verify an issue exists first
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | student1 | Student   | 1        | student1@example.com |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | C1     | student |
+    And the following "activities" exist:
+      | activity   | name                 | intro                      | course | idnumber    |
+      | customcert | Custom certificate 1 | Custom certificate 1 intro | C1     | customcert1 |
+
+  Scenario: An anonymous user cannot probe whether another user has been issued a certificate
+    When I attempt to download the personal certificate PDF for "student1" in "Custom certificate 1"
+    Then I should not see "You have not been issued a certificate"
+    And I should see "Username"
+    And I should see "Password"

--- a/tests/external_test.php
+++ b/tests/external_test.php
@@ -421,4 +421,22 @@ final class external_test extends advanced_testcase {
         $result = external::get_element_html($cert->templateid, $elementid);
         $this->assertIsString($result);
     }
+
+    /**
+     * Test that get_element_html rejects a user who can view the certificate but cannot manage it.
+     *
+     * @covers \mod_customcert\external::get_element_html
+     */
+    public function test_get_element_html_rejects_view_only_capability(): void {
+        $course = $this->getDataGenerator()->create_course();
+        [$cert, , , $elementid] = $this->create_cert_with_element($course);
+
+        // A plain enrolled student has mod/customcert:view but not mod/customcert:manage.
+        $student = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($student->id, $course->id);
+        $this->setUser($student);
+
+        $this->expectException('required_capability_exception');
+        external::get_element_html($cert->templateid, $elementid);
+    }
 }

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -366,4 +366,28 @@ final class lib_test extends advanced_testcase {
         $html = mod_customcert_output_fragment_editelement($args);
         $this->assertIsString($html);
     }
+
+    /**
+     * Test that mod_customcert_output_fragment_editelement rejects a user who can view the
+     * certificate but cannot manage it.
+     *
+     * @covers ::mod_customcert_output_fragment_editelement
+     */
+    public function test_output_fragment_editelement_rejects_view_only_capability(): void {
+        $course = $this->getDataGenerator()->create_course();
+        [, , $elementid, $context] = $this->create_cert_with_element($course);
+
+        // A plain enrolled student has mod/customcert:view but not mod/customcert:manage.
+        $student = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($student->id, $course->id);
+        $this->setUser($student);
+
+        $args = [
+            'elementid' => $elementid,
+            'context'   => $context,
+        ];
+
+        $this->expectException('required_capability_exception');
+        mod_customcert_output_fragment_editelement($args);
+    }
 }

--- a/view.php
+++ b/view.php
@@ -219,6 +219,10 @@ if (!$downloadown && !$downloadissue) {
         $completion = new completion_info($course);
         $completion->set_module_viewed($cm);
     } else if ($downloadissue && $canviewreport) {
+        // Only allow downloading a certificate PDF for a user who has actually been issued one.
+        if (!$DB->record_exists('customcert_issues', ['userid' => $downloadissue, 'customcertid' => $customcert->id])) {
+            throw new moodle_exception('You have not been issued a certificate');
+        }
         $userid = $downloadissue;
     }
 


### PR DESCRIPTION
## Summary

Three security fixes:

- **Missing capability check.** `get_element_html()` and the `editelement` fragment callback (`lib.php`) verified the requested element belongs to the caller's authorised context, but neither checked the caller could actually manage the template. Any user with `mod/customcert:view` could retrieve rendered element HTML or the full admin edit-element form for elements they cannot manage.
- **`downloadissue` exposure.** `view.php`'s report-download flow used the `downloadissue` request parameter directly as the target userid for PDF generation, gated only by `mod/customcert:viewreport`, with no check that the target user was ever issued the certificate.
- **Pre-login existence oracle.** `my_certificates.php`'s certificate-issuance existence check ran before `require_login()`, letting an unauthenticated visitor probe whether an arbitrary userid had been issued an arbitrary certificateid.

CHANGES.md updated with a new `[4.4.12] - 2026-08-06` entry.