### PR TITLE
Security release 5.2.5: missing capability checks and issuance-existence validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 Note - All hash comments refer to the issue number. Eg. #169 refers to https://github.com/mdjnelson/moodle-mod_customcert/issues/169.
 
+## [5.2.5] - 2026-08-10
+
+### Security
+
+- Added a missing capability check so that only users who can manage a certificate template can fetch element HTML or the admin edit-element form via `get_element_html()` and the `editelement` fragment callback (#871).
+- `view.php`'s report-download flow (`downloadissue`) now verifies the target user has actually been issued the certificate before generating a PDF for them, preventing a report-viewer from generating a certificate for an arbitrary user who was never issued one (#871).
+- Moved the login check in `my_certificates.php` above the certificate-issuance existence check, preventing an unauthenticated user from probing whether a given user has been issued a given certificate (#871).
+
 ## [5.2.4] - 2026-08-02
 
 ### Security

--- a/classes/external.php
+++ b/classes/external.php
@@ -178,6 +178,9 @@ class external extends external_api {
             self::validate_context(context_system::instance());
         }
 
+        // Only users who can manage this template may fetch its element HTML.
+        $template->require_manage();
+
         // Load the element, verifying it belongs to the authorised template.
         $elementrepo = new element_repository(element_factory::build_with_defaults());
         $element = $elementrepo->get_for_template_or_fail((int)$templateid, (int)$elementid);

--- a/lib.php
+++ b/lib.php
@@ -334,6 +334,9 @@ function mod_customcert_output_fragment_editelement($args) {
         throw new moodle_exception('nopermissions', 'error', '', 'editelement');
     }
 
+    // Only users who can manage this template may view the admin edit-element form.
+    template::from_record($templaterecord)->require_manage();
+
     // Load the element, verifying it belongs to the authorised template.
     $element = $elementrepo->get_for_template_or_fail((int)$args['templateid'], (int)$args['elementid']);
 

--- a/my_certificates.php
+++ b/my_certificates.php
@@ -36,6 +36,15 @@ $userid = optional_param('userid', $USER->id, PARAM_INT);
 $download = optional_param('download', null, PARAM_ALPHA);
 $courseid = optional_param('course', null, PARAM_INT);
 $downloadcert = optional_param('downloadcert', '', PARAM_BOOL);
+
+// Requires a login. This must happen before any data-dependent checks below, so that
+// an unauthenticated request cannot be used to probe certificate-issuance existence.
+if ($courseid) {
+    require_login($courseid);
+} else {
+    require_login();
+}
+
 if ($downloadcert) {
     $certificateid = required_param('certificateid', PARAM_INT);
     $certrepo = new certificate_repository();
@@ -50,13 +59,6 @@ $page = optional_param('page', 0, PARAM_INT);
 $perpage = optional_param('perpage', pagination::CUSTOMCERT_PER_PAGE, PARAM_INT);
 $pageurl = $url = new moodle_url('/mod/customcert/my_certificates.php', ['userid' => $userid,
     'page' => $page, 'perpage' => $perpage]);
-
-// Requires a login.
-if ($courseid) {
-    require_login($courseid);
-} else {
-    require_login();
-}
 
 // Check that we have a valid user.
 $user = core_user::get_user($userid, '*', MUST_EXIST);

--- a/tests/behat/behat_mod_customcert.php
+++ b/tests/behat/behat_mod_customcert.php
@@ -162,4 +162,29 @@ class behat_mod_customcert extends behat_base {
         $url = new moodle_url('/mod/customcert/verify_certificate.php');
         $this->getSession()->visit($this->locate_path($url->out_as_local_url()));
     }
+
+    /**
+     * Directs the current (possibly logged-out) user to the personal certificate download URL
+     * for another user.
+     *
+     * Used to test that the certificate-issuance existence check cannot be probed before the
+     * caller is authenticated.
+     *
+     * phpcs:ignore
+     * @Given /^I attempt to download the personal certificate PDF for "(?P<user_name>(?:[^"]|\\")*)" in "(?P<certificate_name>(?:[^"]|\\")*)"$/
+     * @param string $username
+     * @param string $certificatename
+     */
+    public function i_attempt_to_download_the_personal_certificate_pdf_for($username, $certificatename) {
+        global $DB;
+
+        $certificate = $DB->get_record('customcert', ['name' => $certificatename], '*', MUST_EXIST);
+        $user = $DB->get_record('user', ['username' => $username], '*', MUST_EXIST);
+
+        $url = new moodle_url(
+            '/mod/customcert/my_certificates.php',
+            ['downloadcert' => 1, 'certificateid' => $certificate->id, 'userid' => $user->id]
+        );
+        $this->getSession()->visit($this->locate_path($url->out_as_local_url(false)));
+    }
 }

--- a/tests/behat/download_authorisation.feature
+++ b/tests/behat/download_authorisation.feature
@@ -1,0 +1,25 @@
+@mod @mod_customcert
+Feature: Certificate downloads verify issuance before generating a PDF
+  In order to prevent certificate data being generated for the wrong user
+  As a developer
+  I need personal-download requests to verify an issue exists first
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | student1 | Student   | 1        | student1@example.com |
+    And the following "course enrolments" exist:
+      | user     | course | role    |
+      | student1 | C1     | student |
+    And the following "activities" exist:
+      | activity   | name                 | intro                      | course | idnumber    |
+      | customcert | Custom certificate 1 | Custom certificate 1 intro | C1     | customcert1 |
+
+  Scenario: An anonymous user cannot probe whether another user has been issued a certificate
+    When I attempt to download the personal certificate PDF for "student1" in "Custom certificate 1"
+    Then I should not see "You have not been issued a certificate"
+    And I should see "Username"
+    And I should see "Password"

--- a/tests/external_test.php
+++ b/tests/external_test.php
@@ -659,4 +659,22 @@ final class external_test extends advanced_testcase {
         $result = external::get_element_html($cert->templateid, $elementid);
         $this->assertIsString($result);
     }
+
+    /**
+     * Test that get_element_html rejects a user who can view the certificate but cannot manage it.
+     *
+     * @covers \mod_customcert\external::get_element_html
+     */
+    public function test_get_element_html_rejects_view_only_capability(): void {
+        $course = $this->getDataGenerator()->create_course();
+        [$cert, , , $elementid] = $this->create_cert_with_element($course);
+
+        // A plain enrolled student has mod/customcert:view but not mod/customcert:manage.
+        $student = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($student->id, $course->id);
+        $this->setUser($student);
+
+        $this->expectException('required_capability_exception');
+        external::get_element_html($cert->templateid, $elementid);
+    }
 }

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -377,4 +377,29 @@ final class lib_test extends advanced_testcase {
         $html = mod_customcert_output_fragment_editelement($args);
         $this->assertIsString($html);
     }
+
+    /**
+     * Test that mod_customcert_output_fragment_editelement rejects a user who can view the
+     * certificate but cannot manage it.
+     *
+     * @covers ::mod_customcert_output_fragment_editelement
+     */
+    public function test_output_fragment_editelement_rejects_view_only_capability(): void {
+        $course = $this->getDataGenerator()->create_course();
+        [, , $elementid, $templateid, $context] = $this->create_cert_with_element($course);
+
+        // A plain enrolled student has mod/customcert:view but not mod/customcert:manage.
+        $student = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($student->id, $course->id);
+        $this->setUser($student);
+
+        $args = [
+            'elementid'  => $elementid,
+            'templateid' => $templateid,
+            'context'    => $context,
+        ];
+
+        $this->expectException('required_capability_exception');
+        mod_customcert_output_fragment_editelement($args);
+    }
 }

--- a/view.php
+++ b/view.php
@@ -237,6 +237,10 @@ if (!$downloadown && !$downloadissue) {
         $completion = new completion_info($course);
         $completion->set_module_viewed($cm);
     } else if ($downloadissue && $canviewreport) {
+        // Only allow downloading a certificate PDF for a user who has actually been issued one.
+        if (!(new issue_repository())->exists_for_user((int)$customcert->id, (int)$downloadissue)) {
+            throw new moodle_exception('You have not been issued a certificate');
+        }
         $userid = $downloadissue;
     }
 


### PR DESCRIPTION
## Summary

Three security fixes:

- **Missing capability check.** `get_element_html()` and the `editelement` fragment callback (`lib.php`) verified the requested element belongs to the caller's authorised context, but neither checked the caller could actually manage the template. Any user with `mod/customcert:view` could retrieve rendered element HTML or the full admin edit-element form for elements they cannot manage.
- **`downloadissue` exposure.** `view.php`'s report-download flow used the `downloadissue` request parameter directly as the target userid for PDF generation, gated only by `mod/customcert:viewreport`, with no check that the target user was ever issued the certificate.
- **Pre-login existence oracle.** `my_certificates.php`'s certificate-issuance existence check ran before `require_login()`, letting an unauthenticated visitor probe whether an arbitrary userid had been issued an arbitrary certificateid.

CHANGES.md updated with a new `[5.2.5] - 2026-08-06` entry.