### PR TITLE
Add test coverage for callback classes and PDF/HTML renderers

### DIFF
--- a/tests/course_callbacks_test.php
+++ b/tests/course_callbacks_test.php
@@ -1,0 +1,104 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+declare(strict_types=1);
+
+namespace mod_customcert;
+
+use advanced_testcase;
+use mod_customcert\callback\course_callbacks;
+use mod_customcert\service\certificate_issue_service;
+use mod_customcert\service\issue_repository;
+
+/**
+ * Unit tests for classes/callback/course_callbacks.php.
+ *
+ * reset_userdata() bulk-deletes issued certificates on course reset. A scoping bug (e.g. an
+ * incorrect join/filter) would silently delete issue history for the wrong course, which is
+ * destructive and would only be discovered after the fact.
+ *
+ * @package    mod_customcert
+ * @category   test
+ * @copyright  2026 Mark Nelson <mdjnelson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class course_callbacks_test extends advanced_testcase {
+    /**
+     * Test set up.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+
+        parent::setUp();
+    }
+
+    /**
+     * reset_userdata() must only delete issues for the course being reset, leaving issues in
+     * other courses (even ones using the same element/template shape) untouched.
+     *
+     * @covers \mod_customcert\callback\course_callbacks::reset_userdata
+     */
+    public function test_reset_userdata_only_deletes_issues_for_the_given_course(): void {
+        $this->setAdminUser();
+
+        $coursea = $this->getDataGenerator()->create_course();
+        $courseb = $this->getDataGenerator()->create_course();
+
+        $certa = $this->getDataGenerator()->create_module('customcert', ['course' => $coursea->id]);
+        $certb = $this->getDataGenerator()->create_module('customcert', ['course' => $courseb->id]);
+
+        $usera = $this->getDataGenerator()->create_user();
+        $userb = $this->getDataGenerator()->create_user();
+
+        $issueservice = certificate_issue_service::create();
+        $issuea = $issueservice->issue_certificate((int)$certa->id, (int)$usera->id);
+        $issueb = $issueservice->issue_certificate((int)$certb->id, (int)$userb->id);
+
+        $status = course_callbacks::reset_userdata((object) [
+            'courseid' => $coursea->id,
+            'reset_customcert' => 1,
+        ]);
+
+        $issuerepo = new issue_repository();
+        $this->assertEmpty($issuerepo->list_by_certificate((int)$certa->id));
+        // Get_records() keys the result by id, not sequential index.
+        $this->assertArrayHasKey($issueb, $issuerepo->list_by_certificate((int)$certb->id));
+
+        $this->assertCount(1, $status);
+        $this->assertSame(false, $status[0]['error']);
+    }
+
+    /**
+     * reset_userdata() must not touch any issues, and must return an empty status array, when
+     * reset_customcert was not selected.
+     *
+     * @covers \mod_customcert\callback\course_callbacks::reset_userdata
+     */
+    public function test_reset_userdata_noop_when_not_selected(): void {
+        $this->setAdminUser();
+
+        $course = $this->getDataGenerator()->create_course();
+        $customcert = $this->getDataGenerator()->create_module('customcert', ['course' => $course->id]);
+        $user = $this->getDataGenerator()->create_user();
+
+        certificate_issue_service::create()->issue_certificate((int)$customcert->id, (int)$user->id);
+
+        $status = course_callbacks::reset_userdata((object) ['courseid' => $course->id]);
+
+        $this->assertSame([], $status);
+        $this->assertCount(1, (new issue_repository())->list_by_certificate((int)$customcert->id));
+    }
+}

--- a/tests/file_callbacks_test.php
+++ b/tests/file_callbacks_test.php
@@ -1,0 +1,149 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+declare(strict_types=1);
+
+namespace mod_customcert;
+
+use advanced_testcase;
+use context_module;
+use context_system;
+use mod_customcert\callback\file_callbacks;
+use moodle_exception;
+
+/**
+ * Unit tests for classes/callback/file_callbacks.php.
+ *
+ * pluginfile() is the access-control gate for serving certificate template images:
+ * CONTEXT_MODULE requests must be logged in to the course, CONTEXT_SYSTEM requests must
+ * hold mod/customcert:manage. A weakened or dropped check here would leak files with
+ * nothing failing, so this locks both branches down explicitly.
+ *
+ * @package    mod_customcert
+ * @category   test
+ * @copyright  2026 Mark Nelson <mdjnelson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class file_callbacks_test extends advanced_testcase {
+    /**
+     * Test set up.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+
+        parent::setUp();
+    }
+
+    /**
+     * Only the 'image' filearea is handled; anything else must be a no-op.
+     *
+     * @covers \mod_customcert\callback\file_callbacks::pluginfile
+     */
+    public function test_pluginfile_ignores_non_image_filearea(): void {
+        $this->setAdminUser();
+        $course = $this->getDataGenerator()->create_course();
+        $customcert = $this->getDataGenerator()->create_module('customcert', ['course' => $course->id]);
+        $cm = get_coursemodule_from_instance('customcert', $customcert->id, $course->id, false, MUST_EXIST);
+        $context = context_module::instance($cm->id);
+
+        $result = file_callbacks::pluginfile($course, $cm, $context, 'other', ['file.png'], false);
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * A CONTEXT_SYSTEM request without mod/customcert:manage must be denied before any file
+     * lookup happens.
+     *
+     * @covers \mod_customcert\callback\file_callbacks::pluginfile
+     */
+    public function test_pluginfile_system_context_denies_without_manage_capability(): void {
+        $student = $this->getDataGenerator()->create_user();
+        $this->setUser($student);
+
+        $course = new \stdClass();
+        $context = context_system::instance();
+        $cm = new \stdClass();
+
+        $result = file_callbacks::pluginfile($course, $cm, $context, 'image', ['file.png'], false);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * A CONTEXT_SYSTEM request with mod/customcert:manage must pass the capability check and
+     * proceed to the (here, unsuccessful) file lookup, proving the check doesn't also block
+     * legitimate managers.
+     *
+     * @covers \mod_customcert\callback\file_callbacks::pluginfile
+     */
+    public function test_pluginfile_system_context_allows_with_manage_capability(): void {
+        $this->setAdminUser();
+
+        $course = new \stdClass();
+        $context = context_system::instance();
+        $cm = new \stdClass();
+
+        $result = file_callbacks::pluginfile($course, $cm, $context, 'image', ['does-not-exist.png'], false);
+
+        // No such file exists, so it must fail closed with false rather than error or serve
+        // something unexpected — but critically, it got past the capability check to do so.
+        $this->assertFalse($result);
+    }
+
+    /**
+     * A CONTEXT_MODULE request from a user who isn't logged in to the course must be rejected
+     * by require_login(), not silently allowed through.
+     *
+     * pluginfile() calls require_login($course, false, $cm) without $preventredirect, so for an
+     * anonymous user require_login() takes the "redirect to the login page" branch rather than
+     * throwing require_login_exception (that's only thrown when $preventredirect is true). Under
+     * PHPUnit an actual HTTP redirect can't happen, so Moodle raises a generic moodle_exception
+     * ("Unsupported redirect detected") instead — that's the real, observable rejection here.
+     *
+     * @covers \mod_customcert\callback\file_callbacks::pluginfile
+     */
+    public function test_pluginfile_module_context_requires_login(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $customcert = $this->getDataGenerator()->create_module('customcert', ['course' => $course->id]);
+        $cm = get_coursemodule_from_instance('customcert', $customcert->id, $course->id, false, MUST_EXIST);
+        $context = context_module::instance($cm->id);
+
+        $this->expectException(moodle_exception::class);
+        file_callbacks::pluginfile($course, $cm, $context, 'image', ['file.png'], false);
+    }
+
+    /**
+     * A CONTEXT_MODULE request from a user who is logged in to the course must pass the
+     * login check and proceed to the (here, unsuccessful) file lookup.
+     *
+     * @covers \mod_customcert\callback\file_callbacks::pluginfile
+     */
+    public function test_pluginfile_module_context_allows_with_login(): void {
+        $course = $this->getDataGenerator()->create_course();
+        $customcert = $this->getDataGenerator()->create_module('customcert', ['course' => $course->id]);
+        $cm = get_coursemodule_from_instance('customcert', $customcert->id, $course->id, false, MUST_EXIST);
+        $context = context_module::instance($cm->id);
+
+        $student = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($student->id, $course->id);
+        $this->setUser($student);
+
+        $result = file_callbacks::pluginfile($course, $cm, $context, 'image', ['does-not-exist.png'], false);
+
+        $this->assertFalse($result);
+    }
+}

--- a/tests/html_renderer_test.php
+++ b/tests/html_renderer_test.php
@@ -1,0 +1,144 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+declare(strict_types=1);
+
+namespace mod_customcert;
+
+use advanced_testcase;
+use context_system;
+use mod_customcert\element\renderable_element_interface;
+use mod_customcert\service\element_factory;
+use mod_customcert\service\html_renderer;
+use pdf;
+
+/**
+ * Unit tests for the html_renderer class.
+ *
+ * html_renderer is already exercised indirectly through
+ * preview_renderer::render_html_page() (see preview_renderer_test.php), but that only
+ * proves the overall designer-preview pipeline works — it never verifies html_renderer's
+ * own contract in isolation (e.g. that render_pdf() is a genuine no-op). These tests cover
+ * that directly.
+ *
+ * @package    mod_customcert
+ * @category   test
+ * @copyright  2026 Mark Nelson <mdjnelson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class html_renderer_test extends advanced_testcase {
+    /**
+     * Test set up.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+
+        parent::setUp();
+    }
+
+    /**
+     * Create a real text element instance backed by a DB record.
+     *
+     * @return renderable_element_interface
+     */
+    private function create_text_element(): renderable_element_interface {
+        global $DB;
+
+        $templateid = $DB->insert_record('customcert_templates', (object) [
+            'name' => 'Test template',
+            'contextid' => context_system::instance()->id,
+            'timecreated' => time(),
+            'timemodified' => time(),
+        ]);
+        $pageid = $DB->insert_record('customcert_pages', (object) [
+            'templateid' => $templateid,
+            'width' => 210,
+            'height' => 297,
+            'sequence' => 1,
+            'timecreated' => time(),
+            'timemodified' => time(),
+        ]);
+        $elementid = $DB->insert_record('customcert_elements', (object) [
+            'pageid' => $pageid,
+            'element' => 'text',
+            'name' => 'Test element',
+            'data' => json_encode([
+                'text' => 'Hello HTML',
+                'font' => 'times',
+                'fontsize' => 12,
+                'colour' => '#000000',
+                'width' => 0,
+            ]),
+            'sequence' => 1,
+            'timecreated' => time(),
+            'timemodified' => time(),
+        ]);
+        $record = $DB->get_record('customcert_elements', ['id' => $elementid], '*', MUST_EXIST);
+
+        return element_factory::build_with_defaults()->create_from_record($record);
+    }
+
+    /**
+     * render_pdf() must be a genuine no-op: passing a pdf object with no page added must not
+     * throw, which it would if the renderer tried to actually write content to it.
+     *
+     * @covers \mod_customcert\service\html_renderer::render_pdf
+     */
+    public function test_render_pdf_is_a_noop(): void {
+        global $CFG, $USER;
+        require_once($CFG->libdir . '/pdflib.php');
+
+        $renderer = new html_renderer();
+        $pdf = new pdf();
+        $element = $this->create_text_element();
+
+        // No AddPage() call: if render_pdf() were not a no-op, writing to a pageless
+        // pdf would throw.
+        $renderer->render_pdf($element, $pdf, true, $USER);
+        $this->assertDebuggingNotCalled();
+    }
+
+    /**
+     * render_html() delegates to the element's own render_html() method.
+     *
+     * @covers \mod_customcert\service\html_renderer::render_html
+     */
+    public function test_render_html_delegates_to_element(): void {
+        $renderer = new html_renderer();
+        $element = $this->create_text_element();
+
+        $html = $renderer->render_html($element);
+
+        $this->assertIsString($html);
+        $this->assertStringContainsString('Hello HTML', $html);
+    }
+
+    /**
+     * render_content() delegates to element_helper::render_html_content().
+     *
+     * @covers \mod_customcert\service\html_renderer::render_content
+     */
+    public function test_render_content_delegates_to_element_helper(): void {
+        $renderer = new html_renderer();
+        $element = $this->create_text_element();
+
+        $html = $renderer->render_content($element, 'Sample content');
+
+        $this->assertIsString($html);
+        $this->assertStringContainsString('Sample content', $html);
+        $this->assertStringContainsString('<div', $html);
+    }
+}

--- a/tests/instance_callbacks_test.php
+++ b/tests/instance_callbacks_test.php
@@ -1,0 +1,160 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+declare(strict_types=1);
+
+namespace mod_customcert;
+
+use advanced_testcase;
+use context_module;
+use mod_customcert\callback\instance_callbacks;
+use mod_customcert\event\issue_deleted;
+use mod_customcert\service\certificate_issue_service;
+use mod_customcert\service\issue_repository;
+use mod_customcert\service\template_repository;
+
+/**
+ * Unit tests for classes/callback/instance_callbacks.php.
+ *
+ * @package    mod_customcert
+ * @category   test
+ * @copyright  2026 Mark Nelson <mdjnelson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class instance_callbacks_test extends advanced_testcase {
+    /**
+     * Test set up.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+
+        parent::setUp();
+    }
+
+    /**
+     * add_instance() must create a linked template with one page, and encode the
+     * submitted protection checkboxes into the stored protection string.
+     *
+     * The generator itself calls add_instance() (matching Moodle's real module-creation
+     * flow, which first creates the course_modules row before invoking it), so this test
+     * asserts on add_instance()'s specific outcomes rather than re-implementing that
+     * bootstrapping by hand.
+     *
+     * @covers \mod_customcert\callback\instance_callbacks::add_instance
+     */
+    public function test_add_instance_creates_linked_template_and_page(): void {
+        global $DB;
+
+        $this->setAdminUser();
+        $course = $this->getDataGenerator()->create_course();
+
+        $customcert = $this->getDataGenerator()->create_module('customcert', [
+            'course' => $course->id,
+            'protection_print' => 1,
+            'protection_modify' => 1,
+        ]);
+
+        $record = $DB->get_record('customcert', ['id' => $customcert->id], '*', MUST_EXIST);
+        $this->assertNotEmpty($record->templateid);
+
+        $template = (new template_repository())->get_by_id_or_fail((int)$record->templateid);
+        $cm = get_coursemodule_from_instance('customcert', $customcert->id, $course->id, false, MUST_EXIST);
+        $this->assertEquals(context_module::instance($cm->id)->id, $template->contextid);
+
+        $pages = $DB->get_records('customcert_pages', ['templateid' => $template->id]);
+        $this->assertCount(1, $pages);
+
+        $this->assertSame('print, modify', $record->protection);
+    }
+
+    /**
+     * update_instance() must persist changes and re-encode the protection checkboxes.
+     *
+     * @covers \mod_customcert\callback\instance_callbacks::update_instance
+     */
+    public function test_update_instance_updates_record_and_protection(): void {
+        global $DB;
+
+        $this->setAdminUser();
+        $course = $this->getDataGenerator()->create_course();
+        $customcert = $this->getDataGenerator()->create_module('customcert', [
+            'course' => $course->id,
+            'name' => 'Original name',
+        ]);
+
+        $original = $DB->get_record('customcert', ['id' => $customcert->id], '*', MUST_EXIST);
+
+        $data = (object) [
+            'instance' => $customcert->id,
+            'name' => 'Updated name',
+            'protection_copy' => 1,
+        ];
+
+        $result = instance_callbacks::update_instance($data, null);
+        $this->assertTrue($result);
+
+        $updated = $DB->get_record('customcert', ['id' => $customcert->id], '*', MUST_EXIST);
+        $this->assertSame('Updated name', $updated->name);
+        $this->assertSame('copy', $updated->protection);
+        $this->assertGreaterThanOrEqual($original->timemodified, $updated->timemodified);
+    }
+
+    /**
+     * delete_instance() must remove the customcert, its issues and its template, and must
+     * fire an issue_deleted event for every issue before deleting it — this is the ordering
+     * a silent regression could break without any test noticing.
+     *
+     * @covers \mod_customcert\callback\instance_callbacks::delete_instance
+     */
+    public function test_delete_instance_removes_everything_and_fires_events(): void {
+        global $DB;
+
+        $this->setAdminUser();
+        $course = $this->getDataGenerator()->create_course();
+        $customcert = $this->getDataGenerator()->create_module('customcert', ['course' => $course->id]);
+        $user = $this->getDataGenerator()->create_user();
+
+        $record = $DB->get_record('customcert', ['id' => $customcert->id], '*', MUST_EXIST);
+        $templateid = (int)$record->templateid;
+
+        $issueid = certificate_issue_service::create()->issue_certificate((int)$customcert->id, (int)$user->id);
+
+        $sink = $this->redirectEvents();
+        $result = instance_callbacks::delete_instance((int)$customcert->id);
+        $events = array_filter($sink->get_events(), fn ($event) => $event instanceof issue_deleted);
+        $sink->close();
+
+        $this->assertTrue($result);
+
+        $this->assertCount(1, $events);
+        $event = reset($events);
+        $this->assertEquals($issueid, $event->objectid);
+        $this->assertEquals($user->id, $event->relateduserid);
+
+        $this->assertFalse($DB->record_exists('customcert', ['id' => $customcert->id]));
+        $this->assertFalse($DB->record_exists('customcert_templates', ['id' => $templateid]));
+        $this->assertEmpty((new issue_repository())->list_by_certificate((int)$customcert->id));
+    }
+
+    /**
+     * delete_instance() must return false, not throw, for an id that doesn't exist.
+     *
+     * @covers \mod_customcert\callback\instance_callbacks::delete_instance
+     */
+    public function test_delete_instance_returns_false_for_unknown_id(): void {
+        $this->assertFalse(instance_callbacks::delete_instance(-1));
+    }
+}

--- a/tests/pdf_renderer_test.php
+++ b/tests/pdf_renderer_test.php
@@ -1,0 +1,164 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+declare(strict_types=1);
+
+namespace mod_customcert;
+
+use advanced_testcase;
+use coding_exception;
+use context_system;
+use mod_customcert\element\renderable_element_interface;
+use mod_customcert\service\element_factory;
+use mod_customcert\service\pdf_renderer;
+use pdf;
+
+/**
+ * Unit tests for the pdf_renderer class.
+ *
+ * pdf_renderer is already exercised indirectly through
+ * pdf_generation_service::generate_pdf() (see pdf_generation_service_test.php), but that
+ * only proves the overall rendering pipeline works — it never verifies pdf_renderer's own
+ * contract in isolation (e.g. that render_content() requires set_pdf() first, or that
+ * render_html() always returns an empty string). These tests cover that directly.
+ *
+ * @package    mod_customcert
+ * @category   test
+ * @copyright  2026 Mark Nelson <mdjnelson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class pdf_renderer_test extends advanced_testcase {
+    /**
+     * Test set up.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+
+        parent::setUp();
+    }
+
+    /**
+     * Create a real text element instance backed by a DB record.
+     *
+     * @return renderable_element_interface
+     */
+    private function create_text_element(): renderable_element_interface {
+        global $DB;
+
+        $templateid = $DB->insert_record('customcert_templates', (object) [
+            'name' => 'Test template',
+            'contextid' => context_system::instance()->id,
+            'timecreated' => time(),
+            'timemodified' => time(),
+        ]);
+        $pageid = $DB->insert_record('customcert_pages', (object) [
+            'templateid' => $templateid,
+            'width' => 210,
+            'height' => 297,
+            'sequence' => 1,
+            'timecreated' => time(),
+            'timemodified' => time(),
+        ]);
+        $elementid = $DB->insert_record('customcert_elements', (object) [
+            'pageid' => $pageid,
+            'element' => 'text',
+            'name' => 'Test element',
+            'data' => json_encode([
+                'text' => 'Hello PDF',
+                'font' => 'times',
+                'fontsize' => 12,
+                'colour' => '#000000',
+                'width' => 0,
+            ]),
+            'sequence' => 1,
+            'timecreated' => time(),
+            'timemodified' => time(),
+        ]);
+        $record = $DB->get_record('customcert_elements', ['id' => $elementid], '*', MUST_EXIST);
+
+        return element_factory::build_with_defaults()->create_from_record($record);
+    }
+
+    /**
+     * render_content() must refuse to run before set_pdf() has been called.
+     *
+     * @covers \mod_customcert\service\pdf_renderer::render_content
+     */
+    public function test_render_content_throws_when_pdf_not_set(): void {
+        $renderer = new pdf_renderer();
+        $element = $this->create_text_element();
+
+        $this->expectException(coding_exception::class);
+        $renderer->render_content($element, 'Hello PDF');
+    }
+
+    /**
+     * render_content() delegates to element_helper::render_content() once a pdf is set.
+     *
+     * @covers \mod_customcert\service\pdf_renderer::set_pdf
+     * @covers \mod_customcert\service\pdf_renderer::render_content
+     */
+    public function test_render_content_delegates_once_pdf_is_set(): void {
+        global $CFG;
+        require_once($CFG->libdir . '/pdflib.php');
+
+        $renderer = new pdf_renderer();
+        $pdf = new pdf();
+        $pdf->AddPage();
+        $renderer->set_pdf($pdf);
+
+        $element = $this->create_text_element();
+
+        // Should not throw now that the pdf has been set.
+        $renderer->render_content($element, 'Hello PDF');
+        $this->assertDebuggingNotCalled();
+    }
+
+    /**
+     * render_html() is not used by the PDF renderer; it must always return an empty string.
+     *
+     * @covers \mod_customcert\service\pdf_renderer::render_html
+     */
+    public function test_render_html_always_returns_empty_string(): void {
+        $renderer = new pdf_renderer();
+        $element = $this->create_text_element();
+
+        $this->assertSame('', $renderer->render_html($element));
+    }
+
+    /**
+     * render_pdf() delegates to the element's own render() method, passing itself through
+     * as the renderer so the element can call back into render_content().
+     *
+     * @covers \mod_customcert\service\pdf_renderer::render_pdf
+     */
+    public function test_render_pdf_delegates_to_element_render(): void {
+        global $CFG, $USER;
+        require_once($CFG->libdir . '/pdflib.php');
+
+        $this->setAdminUser();
+
+        $renderer = new pdf_renderer();
+        $pdf = new pdf();
+        $pdf->AddPage();
+        $renderer->set_pdf($pdf);
+
+        $element = $this->create_text_element();
+
+        $renderer->render_pdf($element, $pdf, true, $USER);
+        $this->assertDebuggingNotCalled();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds direct unit tests for `pdf_renderer`/`html_renderer`'s own contracts (previously only exercised indirectly through the generation pipeline) (#868)
- Adds test coverage for `instance_callbacks::add_instance/update_instance/delete_instance` (#865)
- Adds test coverage for `file_callbacks::pluginfile()`'s access-control branches (#866)
- Adds test coverage for `course_callbacks::reset_userdata()`'s course-scoping behaviour (#867)

Each commit closes one test-coverage gap identified during an internal architecture review of the plugin. No production code is changed — tests only.

## Test plan
- [x] CI run (moodle-plugin-ci phpunit) passes on all matrix legs