### PR TITLE
Architecture review follow-ups: dedup investigation, dead code, SRP fix, shared constant

### DIFF
--- a/classes/service/certificate_issuer_service.php
+++ b/classes/service/certificate_issuer_service.php
@@ -79,6 +79,16 @@ final class certificate_issuer_service {
     /**
      * List eligible users for emailing for a single certificate.
      *
+     * This is a single-certificate public entry point to the same candidate-eligibility rules
+     * used by the batch cron path (process_email_issuance_run(), invoked from
+     * issue_certificates_task). It is not called by that batch path itself — batch processing
+     * loads its certificate list and visibility filtering via
+     * certificate_repository::list_for_issuance_run() instead, since that's cheaper to express
+     * as one SQL query across many certificates than as a per-certificate PHP check. This method
+     * exists for callers (e.g. an external script, or a future "preview eligible recipients"
+     * feature) that need the same eligibility rules for one known certificate id without running
+     * a full batch pass. Keep it — it is intentional API surface, not dead code.
+     *
      * @param int $customcertid
      * @return array keyed by userid
      */

--- a/classes/service/certificate_issuer_service.php
+++ b/classes/service/certificate_issuer_service.php
@@ -242,6 +242,13 @@ final class certificate_issuer_service {
     /**
      * Build the list of eligible users for a certificate within a CM context.
      *
+     * This decides who a *new* certificate should be issued/emailed to, based on capability,
+     * availability, suspension, completion and required-time rules. It is unrelated to
+     * issue_repository::get_conditional_issues_sql(), which scopes the already-issued-certificates
+     * *report* to what the current viewer is permitted to see (excluding managers/admins,
+     * restricting by the viewer's group). Despite both filtering a list of users, they answer
+     * different questions and must not be merged into one another.
+     *
      * @param object $customcert
      * @param object $cm
      * @return array

--- a/classes/service/element_repository.php
+++ b/classes/service/element_repository.php
@@ -328,6 +328,27 @@ final class element_repository {
     }
 
     /**
+     * Resequence remaining elements on a page after one has been deleted.
+     *
+     * Decrements the sequence of every element that came after the deleted element's former
+     * sequence position, closing the gap it left behind.
+     *
+     * @param int $pageid
+     * @param int $deletedsequence The sequence value the deleted element used to have.
+     * @return void
+     * @throws \dml_exception For database errors.
+     */
+    public function resequence_after_delete(int $pageid, int $deletedsequence): void {
+        global $DB;
+
+        $sql = "UPDATE {customcert_elements}
+                   SET sequence = sequence - 1
+                 WHERE pageid = :pageid
+                   AND sequence > :sequence";
+        $DB->execute($sql, ['pageid' => $pageid, 'sequence' => $deletedsequence]);
+    }
+
+    /**
      * Delete an element record and fire the deleted event.
      *
      * @param element_interface $element

--- a/classes/service/element_repository.php
+++ b/classes/service/element_repository.php
@@ -96,27 +96,6 @@ final class element_repository {
     }
 
     /**
-     * Return the template contextid that owns the given element, or null if the chain is broken.
-     *
-     * Traverses customcert_elements → customcert_pages → customcert_templates.
-     *
-     * @param int $elementid
-     * @return int|null
-     */
-    public function get_template_context_id_for_element(int $elementid): ?int {
-        global $DB;
-
-        $sql = 'SELECT t.contextid
-                  FROM {customcert_elements} e
-                  JOIN {customcert_pages} p ON p.id = e.pageid
-                  JOIN {customcert_templates} t ON t.id = p.templateid
-                 WHERE e.id = :elementid';
-
-        $contextid = $DB->get_field_sql($sql, ['elementid' => $elementid]);
-        return $contextid !== false ? (int)$contextid : null;
-    }
-
-    /**
      * Load a single element record by id or throw if missing.
      *
      * @param int $id

--- a/classes/service/form_service.php
+++ b/classes/service/form_service.php
@@ -54,6 +54,11 @@ final class form_service {
     public const string PROTECTION_COPY = 'copy';
 
     /**
+     * @var string the separator used to encode/decode customcert.protection as a single string
+     */
+    public const string PROTECTION_SEPARATOR = ', ';
+
+    /**
      * Build the form for an element.
      *
      * @param MoodleQuickForm $mform
@@ -138,7 +143,7 @@ final class form_service {
             $protection[] = self::PROTECTION_COPY;
         }
 
-        return implode(', ', $protection);
+        return implode(self::PROTECTION_SEPARATOR, $protection);
     }
 
     /**

--- a/classes/service/issue_repository.php
+++ b/classes/service/issue_repository.php
@@ -250,6 +250,13 @@ final class issue_repository {
     /**
      * Returns an array of the conditional variables to use in the get_issues SQL query.
      *
+     * This scopes the issues *report* to what the current viewer ($USER) is permitted to see:
+     * it excludes cert managers/admins from the listing and, in separate groups mode, restricts
+     * results to the viewer's own group. It is unrelated to certificate_issuer_service's
+     * candidate-eligibility logic (completion, availability, suspension, required time), which
+     * decides who a *new* certificate should be issued/emailed to. Despite both filtering a list
+     * of users, they answer different questions and must not be merged into one another.
+     *
      * @param stdClass $cm the course module
      * @return array the conditional variables
      */

--- a/classes/service/pdf_generation_service.php
+++ b/classes/service/pdf_generation_service.php
@@ -260,7 +260,7 @@ final class pdf_generation_service {
      */
     private function configure_pdf_for_customcert(pdf $pdf, $customcert): void {
         if ($customcert && !empty($customcert->protection)) {
-            $protection = explode(', ', $customcert->protection);
+            $protection = explode(form_service::PROTECTION_SEPARATOR, $customcert->protection);
             $pdf->SetProtection($protection);
         }
         $pdf->setPrintHeader(false);

--- a/classes/service/template_service.php
+++ b/classes/service/template_service.php
@@ -299,8 +299,6 @@ final class template_service {
      * @throws dml_exception
      */
     public function delete_element(template $template, int $elementid): void {
-        global $DB;
-
         $element = $this->elements->get_by_id_or_fail($elementid);
 
         $page = $this->pages->get_by_id_or_fail((int)$element->pageid);
@@ -317,15 +315,10 @@ final class template_service {
                 "deleting record directly without firing element_deleted event.",
                 DEBUG_DEVELOPER
             );
-            $DB->delete_records('customcert_elements', ['id' => $elementid]);
+            $this->elements->delete_by_id($elementid);
         }
 
-        // Resequence remaining elements.
-        $sql = "UPDATE {customcert_elements}
-                   SET sequence = sequence - 1
-                 WHERE pageid = :pageid
-                   AND sequence > :sequence";
-        $DB->execute($sql, ['pageid' => $element->pageid, 'sequence' => $element->sequence]);
+        $this->elements->resequence_after_delete((int)$element->pageid, (int)$element->sequence);
 
         template_updated::create_from_template($template)->trigger();
     }


### PR DESCRIPTION
## Summary
Resolves the five remaining architecture-review findings not covered by test-coverage work:

- **#860** — Investigated the reported duplicate "eligibility" logic between `issue_repository::get_conditional_issues_sql()` and `certificate_issuer_service::get_email_candidates_for_customcert()`. They turned out to answer different questions (report-viewer scoping vs. certificate-issuance eligibility) with no overlapping rules, so instead of forcing a merge, both methods now document the distinction to stop a future maintainer folding them together.
- **#861** — Removed `element_repository::get_template_context_id_for_element()`, a dead method with zero callers anywhere in the plugin (verified via grep).
- **#862** — Investigated why `certificate_issuer_service::list_email_candidates()` has no production callers. Confirmed it's an intentional single-certificate entry point (the batch cron path uses a cheaper SQL-based route instead), not leftover code, and documented that.
- **#863** — Moved the raw `$DB` calls out of `template_service::delete_element()` (a fallback delete and a sibling-resequencing UPDATE) into `element_repository`, matching the pattern `delete_page()` already used elsewhere in the same file.
- **#864** — Added `form_service::PROTECTION_SEPARATOR` and pointed the encode site (`form_service`) and decode site (`pdf_generation_service`) at it instead of two independent `', '` literals.

Each commit addresses exactly one issue. #863 and #864 are behavior-preserving refactors; #860 and #862 are documentation-only; #861 is a deletion of unreachable code.

## Test plan
- [x] CI run (moodle-plugin-ci phpunit/phpcs) passes on all matrix legs
- [x] Existing tests covering `template_service::delete_element()` and protection encode/decode still pass unchanged